### PR TITLE
Fix MG grenade reloading

### DIFF
--- a/ExpansionChangelog.txt
+++ b/ExpansionChangelog.txt
@@ -13,6 +13,7 @@
 //	Axe.txt:						Added A_Setcrosshair(41) to Select and A_Setcrosshair(0) to Deselect states
 //	-Dragonslayer.txt:				Removed
 //	-Dragonslayer2.txt:				Removed
+//	Machinegun.txt:					Added lines to check for AmmoRocket first before allowing a jump to ReloadGrenade in the Reload state
 //	MP40.txt:						Added A_Setcrosshair(41) to Ready2 and A_Setcrosshair(0) to Ready3 states
 //	Railgun.txt:					Added A_Setcrosshair(41) to Ready2 and A_Setcrosshair(0) to Ready3 states
 //	Rifle.txt:						Added A_Setcrosshair(41) to Ready2 and A_Setcrosshair(0) to Ready3 states


### PR DESCRIPTION
Added lines to check for AmmoRocket first in the Reload state before allowing a jump to the GrenadeReload state.