### PR TITLE
Removed crosshair when aiming down the sights

### DIFF
--- a/AmmoDroper.txt
+++ b/AmmoDroper.txt
@@ -12,6 +12,7 @@ ACTOR AmmoDroper : BrutalWeapon
 	
 	Select:
 		TNT1 A 0
+		TNT1 A 0 A_SetCrosshair(41)
 		TNT1 A 1 A_Raise
 		TNT1 AAAAAAAAA 0 A_Raise
 		TNT1 A 0 A_GiveInventory("AmmoDropSlot", 1)
@@ -20,6 +21,7 @@ ACTOR AmmoDroper : BrutalWeapon
 		
 	Deselect:
 		TNT1 A 0
+		TNT1 A 0 A_SetCrosshair(0)
 		TNT1 AAAAAAAAA 0 A_Lower
 		TNT1 AAAAAA 1 A_Lower
 		

--- a/AssaultShotgun.txt
+++ b/AssaultShotgun.txt
@@ -31,7 +31,6 @@ ACTOR AssaultShotgun : BrutalWeapon
 	Ready:
 	Ready3:
 		A12G A 0
-		A12G A 0 A_SetCrosshair(0)
 		A12G A 1 BRIGHT A_WeaponReady(WRF_ALLOWRELOAD)
         A12G A 0 A_JumpIfInventory("Kicking",1,"DoKick")
         A12G A 0 A_JumpIfInventory("Taunting",1,"Taunt")
@@ -48,7 +47,6 @@ ACTOR AssaultShotgun : BrutalWeapon
 		
 	Ready2:
 		A12G A 0
-		A12G A 0 A_SetCrosshair(41)
 		A12A D 1 BRIGHT A_WeaponReady(WRF_ALLOWRELOAD)
         A12G A 0 A_JumpIfInventory("Kicking",1,"DoKick")
         A12G A 0 A_JumpIfInventory("Taunting",1,"Taunt")
@@ -185,6 +183,7 @@ ACTOR AssaultShotgun : BrutalWeapon
 		A12G A 0 A_Giveinventory("Zoomed",1)
         A12G A 0 A_ZoomFactor(1.3)
 		A12G A 0 A_Giveinventory("ADSmode",1)
+		A12G A 0 A_SetCrosshair(41)
         A12A ABC 1 BRIGHT 
         A12G A 0 A_JumpIfInventory("FiredPrimary",1,"Fire")
 		A12A D 1 BRIGHT A_WeaponReady(WRF_ALLOWRELOAD)
@@ -209,6 +208,7 @@ ACTOR AssaultShotgun : BrutalWeapon
 		A12G A 0 A_Takeinventory("Zoomed",1)
         A12G A 0 A_ZoomFactor(1.0)
 		A12G A 0 A_Takeinventory("ADSmode",1)
+		A12G A 0 A_SetCrosshair(0)
 		A12A CBA 1 BRIGHT 
         Goto Ready3
 	
@@ -217,6 +217,7 @@ ACTOR AssaultShotgun : BrutalWeapon
 		RIFG A 0 A_ZoomFactor(1.0)
 		RIFG A 0 A_Takeinventory("Zoomed",1)
 		RIFG A 0 A_Takeinventory("ADSmode",1)
+		A12G A 0 A_SetCrosshair(0)
 		RIFG A 0 A_JumpIfInventory("AutoShotUnloaded",1,"ReadyNoFuckingAmmo")
 		TNT1 A 0 A_PlaySound("weapons/empty", 4)
 		NoAmmo2:
@@ -242,6 +243,7 @@ ACTOR AssaultShotgun : BrutalWeapon
 		A12G A 0 A_Takeinventory("Reloading",1)
 		A12G A 0 A_Takeinventory("ADSmode",1)
 		A12G A 0 A_Takeinventory("Zoomed",1)
+		A12G A 0 A_SetCrosshair(0)
 		A12G A 0 A_JumpIfInventory("AssaultShotgunAmmo",20,"Ready")
 		
         A12G A 0 A_JumpIfInventory("AmmoShell",1,3)
@@ -336,7 +338,7 @@ ACTOR AssaultShotgun : BrutalWeapon
 		A12G A 0 A_Takeinventory("ADSmode",1)
 		A12G A 0 A_Takeinventory("Zoomed",1)
 		A12G A 0 A_ZoomFactor(1.0)
-		
+		A12G A 0 A_SetCrosshair(0)
         A12G A 0 A_JumpIfInventory("AssaultShotgunAmmo",1,3)
         Goto Ready
         TNT1 AAA 0
@@ -392,6 +394,7 @@ ACTOR AssaultShotgun : BrutalWeapon
 		A12G A 0 A_Takeinventory("Zoomed",1)
 		A12G A 0 A_Takeinventory("ADSmode",1)
 		A12G A 0 A_ZoomFactor(1.0)
+		A12G A 0 A_SetCrosshair(0)
 		A12G A 0 A_JumpIfInventory("UsedStamina", 40, "StopSprintTired")
 		
 	Sprinting:	

--- a/DEFAULTWEAPON.txt
+++ b/DEFAULTWEAPON.txt
@@ -154,7 +154,7 @@ ACTOR BrutalWeapon : DoomWeapon
 		TNT1 A 0 A_Takeinventory("Zoomed",1)
         TNT1 A 0 A_ZoomFactor(1.0)
 		TNT1 A 0 A_Takeinventory("ADSmode",1)
-		
+		TNT1 A 0 A_SetCrosshair(0)
 		TNT1 A 0 A_PlaySound("KICK")
 		RIBA ACE 1
 		RIFF A 0 A_FireCustomMissile("KickAttack", 0, 0, 0, 0)
@@ -177,7 +177,7 @@ ACTOR BrutalWeapon : DoomWeapon
 		TNT1 A 0 A_Takeinventory("PowerLightAmp",1)
         TNT1 A 0 A_ZoomFactor(1.0)
 		TNT1 A 0 A_Takeinventory("ADSmode",1)
-		
+		TNT1 A 0 A_SetCrosshair(0)
 		TNT1 A 0 A_JumpIfInventory("ExecuteDownedEnemy", 1, "DoExecution")
 		NULL A 0 A_JumpIf (momZ > 0, "AirKick")
 		NULL A 0 A_JumpIf (momZ < 0, "AirKick")
@@ -461,6 +461,7 @@ ACTOR BrutalWeapon : DoomWeapon
     Taunt:
 		TNT1 A 0 A_Takeinventory("Zoomed",1)
         TNT1 A 0 A_ZoomFactor(1.0)
+		TNT1 A 0 A_SetCrosshair(0)
 		TNT1 A 0 A_Takeinventory("Taunting",1)
 		
         TNT1 A 10
@@ -538,6 +539,7 @@ ACTOR BrutalWeapon : DoomWeapon
 		TNT1 A 0 A_Takeinventory("PowerLightAmp",1)
         TNT1 A 0 A_ZoomFactor(1.0)
 		TNT1 A 0 A_Takeinventory("ADSmode",1)
+		TNT1 A 0 A_SetCrosshair(0)
 		TNT1 A 0 A_JumpIfInventory("IsPlayingAsPurist", 1, "TossGrenadeClassic")
 		GRTH ABCD 1
 		TNT1 A 0 A_GiveInventory("FiredGrenade", 1)
@@ -757,6 +759,7 @@ ACTOR BrutalWeapon : DoomWeapon
 		TNT1 A 0 SetPlayerProperty(0,0,4)
 		KICK A 0 A_Takeinventory("ExecuteDownedEnemy",1)
 		TNT1 A 0 A_takeInventory("PressedUSe", 1)
+		TNT1 A 0 A_SetCrosshair(0)
 		Goto Ready3
 	}
 }

--- a/ExpansionChangelog.txt
+++ b/ExpansionChangelog.txt
@@ -8,12 +8,14 @@
 //	Sounds/COMBAT/WEAPONS folder:	Added the modified PLREADY sound effect from Dox778
 //	Sprites/Monsters folder:		Added SMGGuy idle and LabGuy with the correct axe sprites from Dox778
 //	Sprites/Weapons folder:			Removed all Dragonslayer sprites
+//	AmmoDropper.txt:				Added A_Setcrosshair(41) to Select and A_Setcrosshair(0) to Deselect states
 //	ArchVile.txt:					Added -SOLID flag to DyingArchvileNoArm
 //	Artifact.txt:					Reverted the conditional flare spawns when out of the player's sight
-//	Assaultshotgun.txt:				Added A_Setcrosshair(41) to Ready2 and A_Setcrosshair(0) to Ready3 states
+//	Assaultshotgun.txt:				Added A_Setcrosshair(41) Altfire and A_SetCrosshair(0) to all states that reset zoom to 1.0
 //	Axe.txt:						Added A_Setcrosshair(41) to Select and A_Setcrosshair(0) to Deselect states
 //	Baron.txt:						Removed the Translation property from the DeadBaron actor
 //	DECORATE.txt:					Removed the inclusion of the Dragonslayer2.txt
+//	DEFAULTWEAPON.txt:				Added A_SetCrosshair(0) to all states that reset zoom to 1.0
 //	doomdefs.bm:					Removed the Dragonslayer entries
 //	-Dragonslayer.txt:				Removed
 //	-Dragonslayer2.txt:				Removed
@@ -25,15 +27,16 @@
 //	Lamps.txt:						Reverted the conditional flare spawns when out of the player's sight
 //	Machinegun.txt:					Added lines to check for AmmoRocket first before allowing a jump to ReloadGrenade in the Reload state
 //	MapSpecificDec.txt:				Reverted the conditional flare spawns when out of the player's sight
-//	MP40.txt:						Added A_Setcrosshair(41) to Ready2 and A_Setcrosshair(0) to Ready3 states
-//	Railgun.txt:					Added A_Setcrosshair(41) to Ready2 and A_Setcrosshair(0) to Ready3 states
-//	Rifle.txt:						Added A_Setcrosshair(41) to Ready2 and A_Setcrosshair(0) to Ready3 states
-//	RocketLauncher.txt:				Added A_Setcrosshair(41) to Ready2 and A_Setcrosshair(0) to Ready3 states
+//	MP40.txt:						Added A_Setcrosshair(41) Altfire and A_SetCrosshair(0) to all states that reset zoom to 1.0
+//	Railgun.txt:					Added A_Setcrosshair(41) Altfire and A_SetCrosshair(0) to all states that reset zoom to 1.0
+//	Rifle.txt:						Added A_Setcrosshair(41) Altfire and A_SetCrosshair(0) to all states that reset zoom to 1.0
+//	RocketLauncher.txt:				Added A_Setcrosshair(41) Altfire and A_SetCrosshair(0) to all states that reset zoom to 1.0
+//									Added a GoTaunt state like the Railgun so that PowerLightAmp will be removed if jumping to Taunt from a zoomed state.
 //	Saw.txt:						Added A_Setcrosshair(41) to Select and A_Setcrosshair(0) to Deselect states
 //	Sergeants.txt:					Changed the SMGGuy's Spawn, Stand, and Idle frames to now use the new sprites from Dox778
-//	Shotgun.txt:					Added A_Setcrosshair(41) to Ready2 and A_Setcrosshair(0) to Ready3 states
+//	Shotgun.txt:					Added A_Setcrosshair(41) Altfire and A_SetCrosshair(0) to all states that reset zoom to 1.0
 //									Set the DoKickReloading state to jump to FinishedInsertingShells instead of back to InsertingShells wasting ammo
-//	SubMachinegun.txt:				Added A_Setcrosshair(41) to Ready2 and A_Setcrosshair(0) to Ready3 states
+//	SubMachinegun.txt:				Added A_Setcrosshair(41) Altfire and A_SetCrosshair(0) to all states that reset zoom to 1.0
 //	Torches.txt:					Reverted the conditional flare and particle spawns when out of the player's sight
 //	Volcabus.txt:					Adjusted radius and height to match the monsters increased size from previous edits.
 //									Changed probability of jumping to the Suffer state in Death.Massacre to 128 (rarely happens)

--- a/Mp40.txt
+++ b/Mp40.txt
@@ -24,6 +24,7 @@ ACTOR MP40 : BrutalWeapon
 		RIFG A 0 A_ZoomFactor(1.0)
 		RIFG A 0 A_Takeinventory("Zoomed",1)
 		RIFG A 0 A_Takeinventory("ADSmode",1)
+		MP40 A 0 A_SetCrosshair(0)
 		RIFG A 0 A_JumpIfInventory("TurboReload",1,"TurboReload")
 		TNT1 A 0 A_PlaySound("weapons/empty", 4)
 		NoAmmo2:
@@ -52,7 +53,6 @@ ACTOR MP40 : BrutalWeapon
 	Ready:
 	Ready3:		
 		MP40 A 0
-		TNT1 A 0 A_SetCrosshair(0)
 		MP40 A 1 A_WeaponReady(WRF_ALLOWRELOAD)
         MP40 A 0 A_JumpIfInventory("Kicking",1,"DoKick")
         MP40 A 0 A_JumpIfInventory("Taunting",1,"Taunt")
@@ -77,6 +77,7 @@ ACTOR MP40 : BrutalWeapon
 		MP40 A 0 A_Takeinventory("Zoomed",1)
 		MP40 A 0 A_Takeinventory("ADSmode",1)
 		MP40 A 0 A_ZoomFactor(1.0)
+		MP40 A 0 A_SetCrosshair(0)
 		MP40 A 0 A_JumpIfInventory("UsedStamina", 40, "StopSprintTired")
 		
 	Sprinting:	
@@ -134,7 +135,6 @@ ACTOR MP40 : BrutalWeapon
 		
 	Ready2:
 		TNT1 A 0
-		TNT1 A 0 A_SetCrosshair(41)
 		MP40 A 0 A_JumpIfInventory("FiredPrimary",1,"Fire")
         MP40 A 0 A_JumpIfInventory("Kicking",1,"DoKick")
         MP40 A 0 A_JumpIfInventory("Taunting",1,"Taunt")
@@ -153,6 +153,7 @@ ACTOR MP40 : BrutalWeapon
 		MP40 A 0 A_TakeInventory("TossGrenade", 1)
         MP40 A 0 A_ZoomFactor(1.0)
 		MP40 A 0 A_Takeinventory("ADSmode",1) 
+		MP40 A 0 A_SetCrosshair(0)
         MP4S BA 1
 		TNT1 AAAAAAAAA 0 A_Lower
 		TNT1 A 1 A_Lower
@@ -225,6 +226,7 @@ ACTOR MP40 : BrutalWeapon
 		MP40 A 0 A_Giveinventory("Zoomed",1)
         MP40 A 0 A_ZoomFactor(1.3)
 		MP40 A 0 A_Giveinventory("ADSmode",1)
+		MP40 A 0 A_SetCrosshair(41)
         MP4D CB 1
 		MP40 A 0 A_JumpIfInventory("FiredPrimary",1,"Fire")
 		MP41 A 1 A_WeaponReady(WRF_ALLOWRELOAD)
@@ -255,6 +257,7 @@ ACTOR MP40 : BrutalWeapon
 		MP40 A 0 A_Takeinventory("Zoomed",1)
         MP40 A 0 A_ZoomFactor(1.0)
 		MP40 A 0 A_Takeinventory("ADSmode",1)
+		MP40 A 0 A_SetCrosshair(0)
 		MP4D AB 1
         Goto Ready+6
 		
@@ -268,6 +271,7 @@ ACTOR MP40 : BrutalWeapon
 		MP40 A 0 A_Takeinventory("Reloading",1)
 		MP40 A 0 A_Takeinventory("ADSmode",1)
 		MP40 A 0 A_Takeinventory("Zoomed",1)
+		MP40 A 0 A_SetCrosshair(0)
 		MP40 A 0 A_JumpIfInventory("MP40Ammo",32,64)
         MP40 A 0 A_JumpIfInventory("Mauser9mm",1,3)
         Goto Ready
@@ -333,6 +337,7 @@ ACTOR MP40 : BrutalWeapon
 		MP40 A 0 A_Takeinventory("Unloading",1)
 		MP40 A 0 A_Takeinventory("ADSmode",1)
 		MP40 A 0 A_Takeinventory("Zoomed",1)
+		MP40 A 0 A_SetCrosshair(0)
         MP40 A 0 A_JumpIfInventory("MP40Ammo",1,3)
         Goto NoAmmo
         TNT1 AAA 0

--- a/Railgun.txt
+++ b/Railgun.txt
@@ -26,7 +26,6 @@ ACTOR RailGun : BrutalWeapon
 	Ready:	
 	Ready3:
 		TNT1 A 0
-		TNT1 A 0 A_SetCrosshair(0)
 		RAIL A 0 A_JumpIfInventory("HasUnloadedRG",1,"ReadyUnloaded")
 		RIFG A 0 A_JumpIfInventory("RailgunAmmo",1,1)
 		Goto ReadyNoAmmo
@@ -45,7 +44,6 @@ ACTOR RailGun : BrutalWeapon
 		
 	Ready2:
 		TNT1 A 0
-		TNT1 A 0 A_SetCrosshair(41)
 		RIFG A 0 A_JumpIfInventory("RailgunAmmo",1,1)
 		Goto ReadyNoAmmo
 		SNIP A 1 BRIGHT A_WeaponReady(WRF_ALLOWRELOAD)
@@ -65,6 +63,7 @@ ACTOR RailGun : BrutalWeapon
 		RIFG A 0 A_ZoomFactor(1.0)
 		RIFG A 0 A_Takeinventory("Zoomed",1)
 		RAIL A 0 A_Takeinventory("PowerLightAmp", 1)
+		RAIL A 0 A_SetCrosshair(0)
 	    RAIR B 1 A_WeaponReady(WRF_ALLOWRELOAD)
 		RLNG A 0 A_JumpIfInventory("Unloading",1,"Unload")
         RLNG A 0 A_JumpIfInventory("Reloading",1,"Reload")
@@ -81,8 +80,8 @@ ACTOR RailGun : BrutalWeapon
 		RIFG A 0 A_ZoomFactor(1.0)
 		RIFG A 0 A_Takeinventory("Zoomed",1)
 		RAIL A 0 A_Takeinventory("PowerLightAmp", 1)
-        RAIL A 0 A_ZoomFactor(1.0)
 		RIFG A 0 A_Takeinventory("ADSmode",1)
+		RAIL A 0 A_SetCrosshair(0)
 		RAIL A 0 A_JumpIfInventory("HasUnloadedRG", 1, "ReadyUnloaded")
 		TNT1 A 0 A_PlaySound("weapons/empty", 4)
 	NoAmmo2:
@@ -118,6 +117,7 @@ ACTOR RailGun : BrutalWeapon
 		RAIL A 0 A_Takeinventory("PowerLightAmp", 1)
 		RAIL A 0 A_Takeinventory("Zoomed",1)
         RAIL A 0 A_ZoomFactor(1.0)
+		RAIL A 0 A_SetCrosshair(0)
 		TNT1 AAAAAAAAAA 0 A_Lower
 		TNT1 A 1 A_Lower
 		Wait
@@ -207,6 +207,7 @@ ACTOR RailGun : BrutalWeapon
 		RAIL A 0 A_ZoomFactor(1.0)
 		RAIL A 0 A_Takeinventory("Zoomed",1)
 		RAIL A 0 A_Takeinventory("PowerLightAmp", 1)
+		RAIL A 0 A_SetCrosshair(0)
 		RAIZ AB 1 BRIGHT 
 		RAIL DDDDDD 1 BRIGHT 
 		RAIL A 0 A_PlaySound("RAILR1", 2)
@@ -219,6 +220,7 @@ ACTOR RailGun : BrutalWeapon
 		RAIL A 0 A_ZoomFactor(1.0)
 		RAIL A 0 A_Takeinventory("Zoomed",1)
 		RAIL A 0 A_Takeinventory("PowerLightAmp", 1)
+		RAIL A 0 A_SetCrosshair(0)
 		RAIZ AB 1 BRIGHT 
 		RAIL DDDDDDDDDDDDDDDD 2 BRIGHT 
 		RAIL A 0 A_PlaySound("BEPBEP", 2)
@@ -230,6 +232,7 @@ ACTOR RailGun : BrutalWeapon
 		RAIL A 0 A_Giveinventory("Zoomed",1)
         RAIL A 0 A_ZoomFactor(5.0)
 		RAIL A 0 A_giveinventory("PowerLightAmp", 1)
+		RAIL A 0 A_SetCrosshair(41)
         RAIZ AB 1 BRIGHT
 		
         RAIL A 0 A_JumpIfInventory("FiredPrimary",1,"Fire")
@@ -265,6 +268,7 @@ ACTOR RailGun : BrutalWeapon
 		RAIL A 0 A_Takeinventory("Zoomed",1)
 		RAIL A 0 A_Takeinventory("PowerLightAmp", 1)
         RAIL A 0 A_ZoomFactor(1.0)
+		RAIL A 0 A_SetCrosshair(0)
         Goto Ready
 		
 		
@@ -275,6 +279,7 @@ ACTOR RailGun : BrutalWeapon
 		RAIL A 0 A_Takeinventory("Zoomed",1)
 		RAIL A 0 A_Takeinventory("PowerLightAmp", 1)
 		RAIL A 0 A_ZoomFactor(1.0)
+		RAIL A 0 A_SetCrosshair(0)
 		RAIL A 0 A_JumpIfInventory("RailgunAmmo",50,"Ready")
         RAIL A 0 A_JumpIfInventory("AmmoCell",1,3)
         Goto Ready
@@ -323,6 +328,7 @@ ACTOR RailGun : BrutalWeapon
         RAIL A 0 A_Takeinventory("Unloading",1)
 		RAIL A 0 A_Takeinventory("Zoomed",1)
 		RAIL A 0 A_ZoomFactor(1.0)
+		RAIL A 0 A_SetCrosshair(0)
 		RAIL A 0 A_JumpIfInventory("RailgunAmmo",1,2)
 		Goto Ready
         TNT1 AAAA 0
@@ -364,6 +370,7 @@ ACTOR RailGun : BrutalWeapon
 		RAIL A 0 A_Takeinventory("Zoomed",1)
 		RAIL A 0 A_Takeinventory("ADSmode",1)
 		RAIL A 0 A_ZoomFactor(1.0)
+		RAIL A 0 A_SetCrosshair(0)
 		RAIL A 0 A_JumpIfInventory("UsedStamina", 40, "StopSprintTired")
 		
 	Sprinting:	
@@ -425,6 +432,7 @@ ACTOR RailGun : BrutalWeapon
 		RAIL A 0 A_Takeinventory("Zoomed",1)
 		RAIL A 0 A_Takeinventory("PowerLightAmp", 1)
         RAIL A 0 A_ZoomFactor(1.0)
+		RAIL A 0 A_SetCrosshair(0)
 		Goto Taunt
 	}
 }

--- a/Rifle.txt
+++ b/Rifle.txt
@@ -69,6 +69,7 @@ ACTOR Rifle : BrutalWeapon
 		RIFG A 0 A_Takeinventory("Zoomed",1)
 		RIFG A 0 A_Takeinventory("ADSmode",1)
 		RIFG A 0 A_ZoomFactor(1.0)
+		RIFG A 0 A_SetCrosshair(0)
 		RIFG A 0 A_JumpIfInventory("UsedStamina", 40, "StopSprintTired")
 		
 	Sprinting:	
@@ -143,7 +144,6 @@ ACTOR Rifle : BrutalWeapon
 	Ready:
 	Ready3:
 		RIFG A 0 A_JumpIfInventory("Zoomed",1,"Ready2")
-		TNT1 A 0 A_SetCrosshair(0)
 		RIFG A 1 A_WeaponReady(WRF_ALLOWRELOAD)
 		RIFG A 0 A_JumpIfInventory("TossGrenade",1,"TossGrenade")
 	    RIFG A 0 A_JumpIfInventory("Taunting",1,"Taunt")
@@ -161,7 +161,6 @@ ACTOR Rifle : BrutalWeapon
 		
     Ready2:
 		TNT1 A 0
-		TNT1 A 0 A_SetCrosshair(41)
 		RI2G A 0 A_JumpIfInventory("TossGrenade",1,"TossGrenade")
         RI2G A 0 A_JumpIfInventory("Taunting",1,"Taunt")
         RI2G A 0 A_JumpIfInventory("Reloading",1,"Reload")
@@ -190,6 +189,7 @@ ACTOR Rifle : BrutalWeapon
 		RIFG A 0 A_TakeInventory("Salute2", 1)
 		RIFG A 0 A_Takeinventory("RifleSelected",1)
         RIFG A 0 A_ZoomFactor(1.0)
+		RIFG A 0 A_SetCrosshair(0)
 		RIFS CBA 1
 		TNT1 AAAAAAAAAAAAAAAAAA 0 A_Lower
 		TNT1 A 1 A_Lower
@@ -277,6 +277,7 @@ ACTOR Rifle : BrutalWeapon
 		RI2G A 0 A_Giveinventory("Zoomed",1)
         RI2G A 0 A_ZoomFactor(2.0)
 		RI2G A 0 A_Giveinventory("ADSmode",1)
+		RIFG A 0 A_SetCrosshair(41)
         RIFZ ABC 1
 		
 		RI2G A 0 A_JumpIfInventory("FiredPrimary",1,"Fire")
@@ -313,6 +314,7 @@ ACTOR Rifle : BrutalWeapon
 		RIFG A 0 A_Takeinventory("ZoomHold",1)
         RIFG A 0 A_ZoomFactor(1.0)
 		RIFG A 0 A_Takeinventory("ADSmode",1)
+		RIFG A 0 A_SetCrosshair(0)
 		RIFZ BA 1
         Goto Ready3
 		
@@ -321,6 +323,7 @@ ACTOR Rifle : BrutalWeapon
 		RIFG A 0 A_ZoomFactor(1.0)
 		RIFG A 0 A_Takeinventory("Zoomed",1)
 		RIFG A 0 A_Takeinventory("ADSmode",1)
+		RIFG A 0 A_SetCrosshair(0)
 		RIFG A 0 A_JumpIfInventory("TurboReload",1,"TurboReload")
 		TNT1 A 0 A_PlaySound("weapons/empty", 4)
 		NoAmmo2:
@@ -347,6 +350,7 @@ ACTOR Rifle : BrutalWeapon
 		RIFG A 0 A_ZoomFactor(1.0)
 		RIFG A 0 A_Takeinventory("ADSmode",1)
 		RIFG A 0 A_Takeinventory("Zoomed",1)
+		RIFG A 0 A_SetCrosshair(0)
 		RIFG A 0 A_JumpIfInventory("RifleAmmo",31,76)
 		RIFG A 0 A_JumpIfInventory("TurboReload",1,"TurboReload")
         RIFG A 0 A_JumpIfInventory("Clip2",1,3)
@@ -435,6 +439,7 @@ ACTOR Rifle : BrutalWeapon
 		RIFG A 0 A_Takeinventory("Unloading",1)
 		RIFG A 0 A_Takeinventory("ADSmode",1)
 		RIFG A 0 A_Takeinventory("Zoomed",1)
+		RIFG A 0 A_SetCrosshair(0)
         RIFG A 0 A_JumpIfInventory("RifleAmmo",1,3)
         Goto NoAmmo
         TNT1 AAA 0
@@ -491,6 +496,7 @@ ACTOR Rifle : BrutalWeapon
 		RIFG A 0 A_TakeInventory("Salute1", 1)
 		RIFG A 0 A_TakeInventory("Salute2", 1)
         RIFG A 0 A_ZoomFactor(1.0)
+		RIFG A 0 A_SetCrosshair(0)
 		RIFG A 0 A_SelectWEapon("DualRifles")
 		Goto Ready
 		

--- a/RocketLauncher.txt
+++ b/RocketLauncher.txt
@@ -26,14 +26,13 @@ ACTOR Rocket_Launcher : BrutalWeapon Replaces RocketLauncher
 	Ready3:
 	Ready:
 		TNT1 A 0
-		TNT1 A 0 A_SetCrosshair(0)
 	    RLNG A 1 A_WeaponReady(WRF_ALLOWRELOAD)
 		RLNG A 0 A_JumpIfInventory("Unloading",1,"Unload")
         RLNG A 0 A_JumpIfInventory("Reloading",1,"Reload")
         RLNG A 0 A_JumpIfInventory("Kicking",1,"DoKick")
 		RLNG A 0 A_JumpIfInventory("Salute1", 1, "Salute")
 		RLNG A 0 A_JumpIfInventory("Salute2", 1, "Salute")
-        RLNG A 0 A_JumpIfInventory("Taunting",1,"Taunt")
+        RLNG A 0 A_JumpIfInventory("Taunting",1,"GoTaunt")
 		RLNG A 0 A_JumpIfInventory("TossGrenade",1,"TossGrenade")
 		RLNG A 0 A_JumpIfInventory("IsRunning",1,"CheckSprint")
 		RLNG A 0 A_JumpIfInventory("Zoomed", 1, "Ready2")
@@ -43,12 +42,11 @@ ACTOR Rocket_Launcher : BrutalWeapon Replaces RocketLauncher
 		
 	Ready2:
 		TNT1 A 0
-		TNT1 A 0 A_SetCrosshair(41)
 		SNIP A 1 BRIGHT A_WeaponReady(WRF_ALLOWRELOAD)
 		RLNG A 0 A_JumpIfInventory("FiredPrimary",1,"Fire")
 		RLNG A 0 A_JumpIfInventory("Unloading",1,"Unload")
 		RLNG A 0 A_JumpIfInventory("Kicking",1,"DoKick")
-        RLNG A 0 A_JumpIfInventory("Taunting",1,"Taunt")
+        RLNG A 0 A_JumpIfInventory("Taunting",1,"GoTaunt")
 		RLNG A 0 A_JumpIfInventory("Salute1", 1, "Salute")
 		RLNG A 0 A_JumpIfInventory("Salute2", 1, "Salute")
 		RLNG A 0 A_JumpIfInventory("Reloading",1,"Reload")
@@ -64,7 +62,7 @@ ACTOR Rocket_Launcher : BrutalWeapon Replaces RocketLauncher
         RLNG A 0 A_JumpIfInventory("Kicking",1,"DoKick")
 		RLNG A 0 A_JumpIfInventory("Salute1", 1, "Salute")
 		RLNG A 0 A_JumpIfInventory("Salute2", 1, "Salute")
-        RLNG A 0 A_JumpIfInventory("Taunting",1,"Taunt")
+        RLNG A 0 A_JumpIfInventory("Taunting",1,"GoTaunt")
 		RLNG A 0 A_JumpIfInventory("TossGrenade",1,"TossGrenade")
 		RLNG A 0 A_JumpIfInventory("IsRunning",1,"CheckSprint")
 		Loop	
@@ -75,11 +73,12 @@ ACTOR Rocket_Launcher : BrutalWeapon Replaces RocketLauncher
 		RIFG A 0 A_ZoomFactor(1.0)
 		RIFG A 0 A_Takeinventory("Zoomed",1)
 		RIFG A 0 A_Takeinventory("ADSmode",1)
+		RIFG A 0 A_SetCrosshair(0)
 		TNT1 A 0 A_PlaySound("weapons/empty", 4)
 		RLNG A 0 A_JumpIfInventory("HasUnloadedRL", 1, "ReadyNoAmmo")
 		NoAmmo2:
 		RIFG A 0 A_JumpIfInventory("TossGrenade",1,"TossGrenade")
-	    RIFG A 0 A_JumpIfInventory("Taunting",1,"Taunt")
+	    RIFG A 0 A_JumpIfInventory("Taunting",1,"GoTaunt")
 		RIFG A 0 A_JumpIfInventory("Salute1", 1, "Salute")
 		RIFG A 0 A_JumpIfInventory("Salute2", 1, "Salute")
 		RIFG A 0 A_JumpIfInventory("IsRunning",1,"CheckSprint")
@@ -105,6 +104,7 @@ ACTOR Rocket_Launcher : BrutalWeapon Replaces RocketLauncher
 		RLNG A 0 A_Takeinventory("ADSmode",1)
 		RLNG A 0 A_Takeinventory("PowerLightAmp", 1)
 		RLNG A 0 A_ZoomFactor(1.0)
+		RIFG A 0 A_SetCrosshair(0)
 		RLNG A 0 A_JumpIfInventory("UsedStamina", 40, "StopSprintTired")
 		
 	Sprinting:	
@@ -124,7 +124,7 @@ ACTOR Rocket_Launcher : BrutalWeapon Replaces RocketLauncher
 		MISP A 1 offset(9,32) A_SetPitch(pitch -0.5)
 		RLNG A 0 offset(9,32) A_WeaponReady(WRF_NOBOB)
 		RLNG A 0 A_JumpIfInventory("Kicking",1,"DoKick")
-        RLNG A 0 A_JumpIfInventory("Taunting",1,"Taunt")
+        RLNG A 0 A_JumpIfInventory("Taunting",1,"GoTaunt")
         RLNG A 0 A_JumpIfInventory("Reloading",1,"Reload")
 		RLNG A 0 offset(-9,32) A_GiveInventory("UsedStamina", 8)
 		RLNG A 0 offset(9,33) A_SpawnItemEx("FootStep", 0, 0, 2, 0, 0, -4)
@@ -159,13 +159,23 @@ ACTOR Rocket_Launcher : BrutalWeapon Replaces RocketLauncher
 		RLNG A 0 A_JumpIfInventory("UsedStamina", 60, "StopSprintTired")
 		PLAY A 0 ACS_ExecuteAlways(853, 0, 0, 0, 0)//Makes player slower.
 		Goto Ready
-		
+	
+	GoTaunt:
+		RAIL A 0
+		RAIL A 0 A_Light0
+		RAIL A 0 A_Takeinventory("Zoomed",1)
+		RAIL A 0 A_Takeinventory("PowerLightAmp", 1)
+        RAIL A 0 A_ZoomFactor(1.0)
+		RAIL A 0 A_SetCrosshair(0)
+		Goto Taunt
+	
 	Deselect:
         RLNG A 0
 		RLNG A 0 A_Takeinventory("Zoomed",1)
 		RLNG A 0 A_Takeinventory("PowerLightAmp", 1)
         RLNG A 0 A_ZoomFactor(1.0)
 		RLNG A 0 A_TakeInventory("TossGrenade", 1)
+		RIFG A 0 A_SetCrosshair(0)
 		MISS DCBA 1
 		TNT1 AAAAAAAAAAAAAAAAAA 0 A_Lower
 		TNT1 A 1 A_Lower
@@ -289,6 +299,7 @@ ACTOR Rocket_Launcher : BrutalWeapon Replaces RocketLauncher
 		RLNG A 0 A_ZoomFactor(1.0)
 		RLNG A 0 A_TakeInventory("Zoomed", 1)
 		RLNG A 0 A_Takeinventory("PowerLightAmp", 1)
+		RIFG A 0 A_SetCrosshair(0)
         RLNG A 0 A_JumpIfInventory("RocketRounds",6,"Ready")
         RLNG A 0 A_JumpIfInventory("AmmoRocket",1,3)
         Goto Ready
@@ -341,6 +352,7 @@ ACTOR Rocket_Launcher : BrutalWeapon Replaces RocketLauncher
 		RLNG A 0 A_Takeinventory("Zoomed",1)
 		RLNG A 0 A_Takeinventory("PowerLightAmp", 1)
         RLNG A 0 A_ZoomFactor(1.0)
+		RIFG A 0 A_SetCrosshair(0)
 		RLNG A 0 A_JumpIfInventory("RocketRounds",1,2)
 		Goto Ready
         TNT1 AAAA 0
@@ -374,6 +386,7 @@ ACTOR Rocket_Launcher : BrutalWeapon Replaces RocketLauncher
 		RLNG A 0 A_Giveinventory("Zoomed",1)
         RLNG A 0 A_ZoomFactor(3.0)
 		RLNG A 0 A_giveinventory("PowerLightAmp", 1)
+		RIFG A 0 A_SetCrosshair(41)
         MIAI ABCDE 1
         RLNG A 0 A_JumpIfInventory("FiredPrimary",1,"Fire")
 		SNIP A 1 A_WeaponReady(WRF_ALLOWRELOAD)
@@ -399,6 +412,7 @@ ACTOR Rocket_Launcher : BrutalWeapon Replaces RocketLauncher
 		RLNG A 0 A_Takeinventory("Zoomed",1)
 		RLNG A 0 A_Takeinventory("PowerLightAmp", 1)
         RLNG A 0 A_ZoomFactor(1.0)
+		RIFG A 0 A_SetCrosshair(0)
         Goto Ready	
 		
 

--- a/Shotgun.txt
+++ b/Shotgun.txt
@@ -58,7 +58,6 @@ ACTOR Shot_Gun : BrutalWeapon
 	Ready3:	
 	Ready:
 		TNT1 A 0
-		TNT1 A 0 A_SetCrosshair(0)
         SHTN A 0 A_JumpIfInventory("Kicking",1,"DoKick")
         SHTN A 0 A_JumpIfInventory("Taunting",1,"Taunt")
         SHTN A 0 A_JumpIfInventory("Reloading",1,"Reload")
@@ -76,7 +75,6 @@ ACTOR Shot_Gun : BrutalWeapon
 		
 	Ready2:
 		TNT1 A 0
-		TNT1 A 0 A_SetCrosshair(41)
         SHTN A 0 A_JumpIfInventory("Kicking",1,"DoKick")
         SHTN A 0 A_JumpIfInventory("Taunting",1,"Taunt")
         SHTN A 0 A_JumpIfInventory("Reloading",1,"Reload")
@@ -97,6 +95,7 @@ ACTOR Shot_Gun : BrutalWeapon
 		SHTN A 0 A_Takeinventory("ADSmode",1)
 		SHTN A 0 A_Takeinventory("UseShotgunStrap",1)
         SHTN A 0 A_ZoomFactor(1.0)
+		RIFG A 0 A_SetCrosshair(0)
 		SHSS DCBA 1 BRIGHT 
 		TNT1 AAAAAAAAAAAAAAAAAA 0 A_Lower
 		TNT1 A 1 A_Lower
@@ -172,6 +171,7 @@ ACTOR Shot_Gun : BrutalWeapon
 	   SHTN A 0 A_TakeInventory("Reloading", 1)
 	   SHTN A 0 A_Takeinventory("Zoomed",1)
 	   SHTN A 0 A_ZoomFactor(1.0)
+	   RIFG A 0 A_SetCrosshair(0)
 	   SHTN FG 1
 	   SHTN H 1 A_PlaySound("weapons/sgpump", 3)
 	   SHTN IJ 1
@@ -250,6 +250,7 @@ ACTOR Shot_Gun : BrutalWeapon
 		SHTN A 0 A_Giveinventory("Zoomed",1)
         SHTN A 0 A_ZoomFactor(1.2)
 		SHTN A 0 A_Giveinventory("ADSmode",1)
+		RIFG A 0 A_SetCrosshair(41)
         SHT8 ED 1 BRIGHT 
 		SHTN A 0 A_JumpIfInventory("ShotgunWasEmpty", 1, "Pump3")
         SHTN A 0 A_JumpIfInventory("FiredPrimary",1,"Fire")
@@ -282,6 +283,7 @@ ACTOR Shot_Gun : BrutalWeapon
 		SHTN A 0 A_Takeinventory("Zoomed",1)
         SHTN A 0 A_ZoomFactor(1.0)
 		SHTN A 0 A_Takeinventory("ADSmode",1)
+		RIFG A 0 A_SetCrosshair(0)
 		SHTN A 0 A_Giveinventory("GoSpecial",1)
 		SHT8 DE 1 BRIGHT 
         Goto Ready
@@ -292,6 +294,7 @@ ACTOR Shot_Gun : BrutalWeapon
 		SHTN A 0 A_Takeinventory("Zoomed",1)
         SHTN A 0 A_ZoomFactor(1.0)
 		SHTN A 0 A_Takeinventory("ADSmode",1)
+		RIFG A 0 A_SetCrosshair(0)
 		SHTN A 0 A_Giveinventory("GoSpecial",1)
 		SHTN A 0 A_JumpIfInventory("IsStandingStill", 1, "Ready3")
 		SHTN A 0 A_JumpIfInventory("IsTacticalClass", 1, "StartSprint")
@@ -302,6 +305,7 @@ ACTOR Shot_Gun : BrutalWeapon
 		SHTN A 0 A_Takeinventory("Zoomed",1)
 		SHTN A 0 A_Takeinventory("ADSmode",1)
 		SHTN A 0 A_ZoomFactor(1.0)
+		RIFG A 0 A_SetCrosshair(0)
 		SHTN A 0 A_JumpIfInventory("UsedStamina", 40, "StopSprintTired")
 		
 	Sprinting:	
@@ -367,6 +371,7 @@ ACTOR Shot_Gun : BrutalWeapon
 		SHTN A 0
 	    SHTN A 0 A_Takeinventory("Zoomed",1)
         SHTN A 0 A_ZoomFactor(1.0)
+		RIFG A 0 A_SetCrosshair(0)
 		SHTN A 1 BRIGHT A_WeaponReady
 		SHTN A 0 A_JumpIfInventory("ShotgunAmmo",9,"OkToFire")
 		SHTN A 0 A_JumpIfInventory("ShotgunAmmo", 1, "ReloadNormally")//Check if there is a shell in the chamber
@@ -468,6 +473,7 @@ ACTOR Shot_Gun : BrutalWeapon
 		SHTN A 0 A_Takeinventory("Unloading",1)
 		SHTN A 0 A_Takeinventory("ADSmode",1)
 		SHTN A 0 A_Takeinventory("Zoomed",1)
+		RIFG A 0 A_SetCrosshair(0)
 		SHTN A 0 A_GiveInventory("ShotgunWasEmpty", 1)
         SHTN A 0 A_JumpIfInventory("ShotgunAmmo",1,3)
         Goto NoAmmo
@@ -529,6 +535,7 @@ ACTOR Shot_Gun : BrutalWeapon
 		RIFG A 0 A_ZoomFactor(1.0)
 		RIFG A 0 A_Takeinventory("Zoomed",1)
 		RIFG A 0 A_Takeinventory("ADSmode",1)
+		RIFG A 0 A_SetCrosshair(0)
 		RIFG A 0 A_JumpIfInventory("TurboReload",1,"TurboReload")
 		TNT1 A 0 A_PlaySound("weapons/empty", 4)
 		NoAmmo2:

--- a/SubMachinegun.txt
+++ b/SubMachinegun.txt
@@ -23,7 +23,6 @@ ACTOR BrutalSMG : BrutalWeapon
 	Ready3:
 	Ready:
 		SMGG A 0
-		TNT1 A 0 A_SetCrosshair(0)
 		SMGG A 1 A_WeaponReady(WRF_ALLOWRELOAD)
 		SMGG A 0 A_JumpIfInventory("Zoomed",1,"Ready2")
 		SMGG A 0 A_JumpIfInventory("FiredPrimary",1,"Fire")
@@ -41,7 +40,6 @@ ACTOR BrutalSMG : BrutalWeapon
 		
 	Ready2:
 		TNT1 A 0
-		TNT1 A 0 A_SetCrosshair(41)
         SMGG A 0 A_JumpIfInventory("Kicking",1,"DoKick")
         SMGG A 0 A_JumpIfInventory("Taunting",1,"Taunt")
 		SMGG A 0 A_JumpIfInventory("Salute1", 1, "Salute")
@@ -63,6 +61,7 @@ ACTOR BrutalSMG : BrutalWeapon
 		SMGG A 0 A_Giveinventory("Zoomed",1)
         SMGG A 0 A_ZoomFactor(1.3)
 		SMGG A 0 A_Giveinventory("ADSmode",1)
+		RIFG A 0 A_SetCrosshair(41)
         RIFZ ABC 1
         SMGG A 0 A_JumpIfInventory("FiredPrimary",1,"Fire")
 		SMGA A 1 A_WeaponReady(WRF_ALLOWRELOAD)
@@ -92,6 +91,7 @@ ACTOR BrutalSMG : BrutalWeapon
        NoAim:
 		SMGG A 0 A_Takeinventory("Zoomed",1)
         SMGG A 0 A_ZoomFactor(1.0)
+		RIFG A 0 A_SetCrosshair(0)
 		SMGG A 0 A_Giveinventory("GoSpecial",1)
 		SMGG A 0 A_Takeinventory("ADSmode",1)
 		RIFZ CBA 1
@@ -167,6 +167,7 @@ ACTOR BrutalSMG : BrutalWeapon
 		SMGG A 0 A_TakeInventory("Zoomed", 1)
 		SMGG A 0 A_TakeInventory("ADSMode", 1)
 		SMGG A 0 A_ZoomFactor(1.0)
+		RIFG A 0 A_SetCrosshair(0)
 		TNT1 AAAAAAAAAAAAAAAAAA 0 A_Lower
 		TNT1 A 1 A_Lower
 		Wait
@@ -266,6 +267,7 @@ ACTOR BrutalSMG : BrutalWeapon
 		RIFG A 0 A_ZoomFactor(1.0)
 		RIFG A 0 A_Takeinventory("Zoomed",1)
 		RIFG A 0 A_Takeinventory("ADSmode",1)
+		RIFG A 0 A_SetCrosshair(0)
 		RIFG A 0 A_JumpIfInventory("TurboReload",1,"TurboReload")
 		TNT1 A 0 A_PlaySound("weapons/empty", 4)
 		NoAmmo2:
@@ -295,6 +297,7 @@ ACTOR BrutalSMG : BrutalWeapon
         TNT1 AAA 0
 		SMGG A 0 A_Takeinventory("Zoomed",1)
         SMGG A 0 A_ZoomFactor(1.0)
+		RIFG A 0 A_SetCrosshair(0)
 		SMGG A 0 A_GiveInventory ("Pumping", 1)
 		SMGG A 0 A_Takeinventory("Reloading",1)
 		SMGG A 0 A_JumpIfInventory("TurboReload",1,"TurboReload")
@@ -366,6 +369,7 @@ ACTOR BrutalSMG : BrutalWeapon
 
 		SMGG A 0 A_Takeinventory("Zoomed",1)
         SMGG A 0 A_ZoomFactor(1.0)
+		RIFG A 0 A_SetCrosshair(0)
 		SMGG A 0 A_GiveInventory ("Pumping", 1)
 		SMGG A 0 A_Takeinventory("Reloading",1)
 		SMGG A 0 A_PlaySound("reload")
@@ -424,6 +428,7 @@ ACTOR BrutalSMG : BrutalWeapon
 		SMGG A 0 A_TakeInventory("Salute1", 1)
 		SMGG A 0 A_TakeInventory("Salute2", 1)
         SMGG A 0 A_ZoomFactor(1.0)
+		RIFG A 0 A_SetCrosshair(0)
 		SMGG A 0 A_SelectWEapon("DualSMG")
 		Goto Ready	
 		


### PR DESCRIPTION
Added A_SetCrosshair(0) to all weapon states that reset the zoom to 1.0 and A_SetCrosshair(41) to all weapon states that enable ADS.  Also had to add a GoTaunt state in the RocketLauncher imitating the Railgun so that PowerLightAmp will be removed if taunting while zoomed in with the RL.