### PR TITLE
Captured Marines Fix

### DIFF
--- a/CapturedMarine.txt
+++ b/CapturedMarine.txt
@@ -1,0 +1,868 @@
+
+Actor CapturedMarine Replaces Blursphere
+{
+	Radius 24
+    Height 48
+    Speed 0
+	+THRUACTORS
+    States
+		{
+			Spawn:
+			CAPT A 0
+			TNT1 A 0 ACS_NamedExecuteAlways("BDDisableFriendlyMarines")
+			CAPT A 2
+			TNT1 A 0 A_SpawnItemEx("EvidenceCheckerInvisibility", 0, 0, 0, 0, 0, 0, 0, SXF_NOCHECKPOSITION)
+			TNT1 A 0 A_JumPIfInventory("Clip2", 1, "Invisibility")
+			TNT1 A 0 A_Jump(255, "RifleMarine", "RifleMarine", "ShotgunMarine", "ShotgunMarine", "MinigunMarine", "PlasmaMarine")
+			
+		RifleMarine:
+			TNT1 A 0
+			TNT1 A 0 A_SpawnItem("CapturedMarineBase")
+			Stop
+			
+		ShotgunMarine:
+			TNT1 A 0
+			TNT1 A 0 A_SpawnItem("CapturedMarineShotgun")
+			Stop	
+			
+			
+		MinigunMarine:
+			TNT1 A 0
+			TNT1 A 0 A_SpawnItem("CapturedMarineMinigun")
+			Stop	
+			
+		
+		PlasmaMarine:
+			TNT1 A 0
+			TNT1 A 0 A_SpawnItem("CapturedMarinePlasma")
+			Stop
+		
+		Invisibility:
+			TNT1 A 0
+			TNT1 A 0 A_ChangeFlag("NOBLOCKMAP", 1)
+			TNT1 A 0 A_ChangeFlag("SHOOTABLE", 0)
+			TNT1 A 0 A_SpawnItem("SuperBlursphere")
+			TNT1 A 1
+			Stop
+		
+		}
+}
+
+ACTOR CapturedMarineBase
+{
+    Radius 24
+    Height 48
+    Speed 0
+    Health 100
+	Scale 1.0
+    +SHOOTABLE
+	+FLOORCLIP
+    +SOLID
+	+FRIENDLY
+	-COUNTKILL
+	+FLOORCLIP
+    Painchance 255
+    DamageType Taunt
+	
+	Damagefactor "Avoid", 0.0	Damagefactor "BHFTOnBarrel", 0.0	Damagefactor "Blood", 0.0
+	Damagefactor "CancelTeleportFog", 0.0	Damagefactor "CauseWaterSplash", 0.0	Damagefactor "Crush", 10.0
+	Damagefactor "Cut", 10.0	Damagefactor "Extremepunches", 2.0	Damagefactor "Fatality", 5.0
+	Damagefactor "FriendBullet", 0.0	Damagefactor "GibRemoving", 0.0	Damagefactor "Glass", 0.1
+	Damagefactor "HangingHook", 0.0	Damagefactor "Head", 0.0	Damagefactor "HeadKick", 0.0
+	Damagefactor "HelperMarineFatallity", 0.0	Damagefactor "KillMe", 0.0	Damagefactor "Leg", 0.0
+	Damagefactor "LowKick", 0.5	Damagefactor "MonsterKnocked", 0.0	Damagefactor "PussyGrab", 100.0
+	Damagefactor "Repair", 0.0	Damagefactor "RevenantHitStomach", 0.0	Damagefactor "Saw", 10.0
+	Damagefactor "Slide", 0.5	Damagefactor "SpawnMarine", 0.0	Damagefactor "Taunt", 0.0
+	Damagefactor "TeleportRemover", 0.0	Damagefactor "Use", 1000.0	Damagefactor "Stealth", 0.0
+	
+	DeathSound "*death"
+	PainSound "*pain50"
+    BloodType "Brutal_Blood"
+	DropItem "PoleWithNothing" 255
+	Mass 999999
+    States
+    {
+    Spawn:
+	    TNT1 A 0 A_Stop
+		MARN A 0 ACS_NamedExecuteAlways("CheckIfDM", 0, 0, 0, 0)//Check if Coop
+		TNT1 A 1
+		Goto Spawn1
+	DM:
+		TNT1 A 0
+		TNT1 A 0 A_ChangeFlag("NOBLOCKMAP", 1)
+		TNT1 A 0 A_ChangeFlag("SHOOTABLE", 0)
+		TNT1 A 0 A_SpawnItem("SuperBlursphere")
+		TNT1 A 5000
+		Loop
+		
+	Spawn1:
+        TNT1 A 0 A_CheckSight("Spawn2")
+		CAPT A 1 A_Stop
+        CAPT ABCB 15 A_Stop
+		TNT1 A 0 A_CustomMissile ("OrderTitle3", 50, 0, 0, 2, 90)
+        TNT1 A 0 A_SpawnItem ("KillMe")
+        Loop
+
+    Spawn2:
+        CAPT A 5
+        Goto Spawn1
+
+	Death.Use:
+		TNT1 A 0 A_Playsound ("LETSROCK")
+        CAPT F 12
+        TNT1 A 0 A_NoBlocking
+		TNT1 A 0 A_GiveToTarget("NumberOfAllies", 1)
+		TNT1 A 0 A_SpawnItemEx ("Marine_Rifle",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+        CAPT N 1
+		TNT1 A 0 A_ChangeFLag ("SHOOTABLE", 0)
+		TNT1 A 0 A_ChangeFLag ("SOLID", 0)
+        CAPT N 0
+        Stop
+
+	Conversion:
+		TNT1 A 0 A_NoBlocking
+		TNT1 A 0 A_SpawnItemEx ("WolfensteinSS",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+		TNT1 A 0 A_SpawnItem("teleportfog")
+        TNT1 A 0 A_ChangeFLag ("SHOOTABLE", 0)
+		TNT1 A 0 A_ChangeFLag ("SOLID", 0)
+        CAPT N 0
+        Stop	
+		
+Pain:
+Pain.Blast:
+Pain.ExplosiveImpact:
+Pain.Explosive:
+Pain.Bullet:
+Pain.SSG:
+Pain.Minigun:
+Pain.ImpFatalityMarine:
+Pain.Rip:
+        CAPT P 1
+		TNT1 A 0 A_Stop
+        CAPT P 5 A_Pain
+		TNT1 A 0 A_JumpIfInTargetInventory("EnemyIsArchvile", 1, "Conversion")
+		TNT1 A 0 A_Stop
+        Goto AfterPain
+			
+			
+		AfterPain:
+		CAPT A 1 A_Stop
+        CAPT ABCB 15 A_Stop
+		TNT1 A 0 A_CustomMissile ("OrderTitle3", 50, 0, 0, 2, 90)
+        TNT1 A 0 A_SpawnItem ("KillMe")
+        Loop
+     
+	Death:
+	Death.Bullet:
+		TNT1 A 0 A_ChangeFlag("USESPECIAL", 0)
+		TNT1 A 0 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_ChangeFlag("FRIENDLY", 0)
+		PLAY H 10 A_PlayerScream
+		
+		PLAY I 10 A_NoBlocking
+		PLAY J 10 
+		PLAY KLM 10
+		TNT1 A 0 A_SpawnItem ("MediumBloodSpot")
+		PLAY N -1
+		Stop
+
+    Death.Eat:
+		TNT1 A 0 A_ChangeFlag("FRIENDLY", 0)
+		TNT1 A 0 A_ChangeFlag("USESPECIAL", 0)
+        TNT1 A 0 A_GiveToTarget("EatMe",1)
+		TNT1 A 0 A_CustomMissile ("XDeath1", 1, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("XDeath4", 1, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        XPL1 A 10 A_XScream
+        XPL1 B 20 A_NoBlocking
+        XPL1 CDE 10 
+		TNT1 A 0 A_SpawnItem ("MediumBloodSpot")
+        XPL1 E -1
+        Stop
+
+    Death.Cut:
+	Death.Saw:
+		TNT1 A 0
+		TNT1 A 0 A_ChangeFlag("USESPECIAL", 0)
+		TNT1 A 0 A_ChangeFlag("FRIENDLY", 0)
+		TNT1 A 0 A_CustomMissile ("XDeath1", 1, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("XDeath2", 1, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("XDeath3", 1, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("XDeath4", 1, 0, random (0, 360), 2, random (0, 160))
+        TNT1 A 0 A_CustomMissile ("RipGuts", 50, 0, random (0, 360), 2, random (0, 160))
+        TNT1 A 0 A_CustomMissile ("XDeathHalfMarine", 50, 0, random (0, 360), 2, random (0, 160))
+        TNT1 AA 0 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        XPL2 A 10 A_XScream
+        TNT1 AA 0 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        XPL2 B 20 A_NoBlocking
+		TNT1 A 0 A_SpawnItemEx("RemoveMarine",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+        TNT1 AA 0 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        XPL2 C 10 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        TNT1 AA 0 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        XPL2 DE 10 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_SpawnItem ("MediumBloodSpot")
+        XPL2 E -1
+        Stop
+
+    Death.Slime:
+		TNT1 A 0
+		TNT1 A 0 A_ChangeFlag("USESPECIAL", 0)
+		TNT1 A 0 A_ChangeFlag("FRIENDLY", 0)
+        TNT1 A 0 A_PlaySound("BIGSCREA")
+		TNT1 A 0 A_SpawnItemEx("RemoveMarine",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+        PMET AABBCCDDEEFFGGHHIIIII 10 A_CustomMissile ("PlasmaSmoke", 25, 0, random (0, 180), 2, random (0, 180))
+        PMET IIIIIIIIIIJJJJJJJJJJJJJJJJJJJJJJKKKKKKKKKKKKKKKKKKKKKKKKKKLLLLLLLLLLLLLLL 3 A_CustomMissile ("PlasmaSmoke", 25, 0, random (0, 180), 2, random (0, 180))
+        TNT1 A 0 A_NoBlocking
+        TNT1 A -1
+        Stop
+
+    Death.Minigun:
+		TNT1 A 0
+		TNT1 A 0 A_ChangeFlag("USESPECIAL", 0)
+		TNT1 A 0 A_ChangeFlag("FRIENDLY", 0)
+        TNT1 A 0 A_Jump (128, 3)
+        Goto Death
+        TNT1 AAA 0
+		TNT1 A 0 A_CustomMissile ("XDeath1", 1, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("XDeath2", 1, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("XDeath3", 1, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("XDeath4", 1, 0, random (0, 360), 2, random (0, 160))
+        TNT1 A 0 A_CustomMissile ("RipGuts", 50, 0, random (0, 360), 2, random (0, 160))
+        TNT1 A 0 A_CustomMissile ("XDeathHalfMarine", 50, 0, random (0, 360), 2, random (0, 160))
+        TNT1 AA 0 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        XPL2 A 10 A_XScream
+		TNT1 A 0 A_SpawnItemEx("RemoveMarine",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+        TNT1 AA 0 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        XPL2 B 20 A_NoBlocking
+        TNT1 AA 0 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        XPL2 C 10 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        TNT1 AA 0 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        XPL2 DE 10 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_SpawnItem ("MediumBloodSpot")
+        XPL2 E -1
+        Stop
+
+    Death.Rip:
+		TNT1 A 0
+		TNT1 A 0 A_ChangeFlag("FRIENDLY", 0)
+		TNT1 A 0 A_ChangeFlag("USESPECIAL", 0)
+        TNT1 AAAAAAAAAAA 0 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        XPL3 A 10 A_XScream
+        TNT1 AAAAA 0 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        XPL3 B 20 A_NoBlocking
+		TNT1 A 0 A_SpawnItemEx("RemoveMarine",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+        TNT1 A 0 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        XPL3 C 10 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        TNT1 A 0 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        XPL3 D 10 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        TNT1 A 0 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        XPL3 E 10 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        TNT1 A 0 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        XPL3 F 10 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        TNT1 A 0 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        XPL3 F 10 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_SpawnItem ("MediumBloodSpot")
+        XPL3 F -1
+        Stop
+	Death.Massacre:
+	Death.Explosives:
+	XDeath:
+		TNT1 A 0 ThrustThingZ(0,60,0,1)
+		TNT1 A 0 A_ChangeFlag("USESPECIAL", 0)
+		TNT1 A 0 A_ChangeFlag("FRIENDLY", 0)
+        TNT1 A 0 A_CustomMissile ("MarineXDeath", 0, 0, random (0, 360), 2, random (0, 160))
+		PPOD A 0 A_SpawnItemEx("BasicMarineGib1", 0, 0, 0, 0, 0, 0, 0, SXF_TRANSFERTRANSLATION)
+		PPOD A 0 A_SpawnItemEx("BasicMarineGib2", 0, 0, 0, 0, 0, 0, 0, SXF_TRANSFERTRANSLATION)
+		PPOD A 0 A_SpawnItemEx("BasicMarineGib3", 0, 0, 0, 0, 0, 0, 0, SXF_TRANSFERTRANSLATION)
+		PPOD A 0 A_SpawnItemEx("BasicMarineGib4", 0, 0, 0, 0, 0, 0, 0, SXF_TRANSFERTRANSLATION)
+        MHEA A 7 A_XScream
+        MHEA B 7 A_NoBlocking
+		TNT1 A 0 A_SpawnItemEx("RemoveMarine",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+        MHEA CD 7
+        MHEA E -1
+		Stop
+		
+	 Crush:
+	 Death.Stomp:
+		TNT1 A 0
+		TNT1 A 0 A_ChangeFlag("USESPECIAL", 0)
+		TNT1 A 0 A_ChangeFlag("FRIENDLY", 0)
+	    TNT1 AAAAAAAAAAAAAAAAAAAAAAAAA 0 A_CustomMissile ("Brutal_FlyingBloodTrail8", 0, 0, random (0, 360), 2, random (0, 360))
+		TNT1 AAAAAA 0 bright A_CustomMissile ("SuperGoreSpawner", 5, 0, random (0, 360), 2, random (30, 180))
+		TNT1 AAAAAA 0 bright A_CustomMissile ("XDeath1", 5, 0, random (0, 360), 2, random (30, 180))
+		TNT1 AA 0 bright A_CustomMissile ("XDeath2", 55, 0, random (0, 360), 2, random (30, 180))
+		TNT1 AA 0 bright A_CustomMissile ("XDeath3", 55, 0, random (0, 360), 2, random (30, 180))
+		TNT1 A 0 A_SpawnItem ("GrowingBloodPool")
+		TNT1 A 0 A_SpawnItem ("CrushedRemains")
+		TNT1 A 0 A_SpawnItemEx("RemoveMarine",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+		TNT1 A 1
+		TNT1 A 1 A_XScream
+		TNT1 A 1 A_NoBlocking
+		Stop	
+
+	Death.Blast:
+	Death.SuperPunch:
+	Death.SSG:
+		TNT1 A 0
+		TNT1 A 0 A_ChangeFlag("USESPECIAL", 0)
+		TNT1 A 0 A_ChangeFlag("FRIENDLY", 0)
+	    PLAY O 2 A_FaceTarget
+        TNT1 AAAA 0 A_CustomMissile ("XDeath1", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile ("XDeath2", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile ("XDeath3", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile ("Brutal_FlyingBlood", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile ("Brutal_FlyingBloodFaster", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile ("Brutal_FlyingBloodMuchFaster", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile ("SuperWallRedBlood", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile ("SuperWallRedBlood", 46, 0, random (170, 190), 2, random (0, 40))
+		TNT1 A 0 A_CustomMissile ("XDeathArm1", 32, 0, random (170, 190), 2, random (0, 40))
+        TNT1 A 0 A_XScream
+		TNT1 A 0 A_NoBlocking
+		TNT1 A 0 A_SpawnItemEx("RemoveMarine",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+        PLAY OPQRSTU 8
+		TNT1 A 0 A_SpawnItem ("MediumBloodSpot")
+        PLAY U -1
+        Stop
+
+    Death.Rape:
+		TNT1 A 0
+		TNT1 A 0 A_ChangeFlag("USESPECIAL", 0)
+		TNT1 A 0 A_ChangeFlag("FRIENDLY", 0)
+		TNT1 AAAAAAAAAAAAAA 0 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+		XPL4 A 20 A_XScream
+		 TNT1 A 0 A_CustomMissile ("XDeath1", 1, 0, random (0, 360), 2, random (0, 160))
+		 TNT1 A 0 A_CustomMissile ("XDeath2", 1, 0, random (0, 360), 2, random (0, 160))
+		 TNT1 A 0 A_CustomMissile ("XDeath3", 1, 0, random (0, 360), 2, random (0, 160))
+		 TNT1 A 0 A_CustomMissile ("XDeath4", 1, 0, random (0, 360), 2, random (0, 160))
+        TNT1 AAAA 0 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        XPL4 B 20 A_NoBlocking
+		TNT1 A 0 A_SpawnItemEx("RemoveMarine",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+        TNT1 AAA 0 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        XPL4 C 20
+        TNT1 AAA 0 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        XPL4 D 20
+        TNT1 AAAA 0 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        XPL4 E 20
+        TNT1 AAA 0 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        XPL4 F 20
+        TNT1 AAAA 0 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_SpawnItem ("MediumBloodSpot")
+        XPL4 F -1
+        Stop
+
+    Death.plasma:
+        TNT1 A 0
+		TNT1 A 0 A_ChangeFlag("USESPECIAL", 0)
+		TNT1 A 0 A_ChangeFlag("FRIENDLY", 0)
+        TNT1 A 0 A_XScream
+        TNT1 A 0 A_NoBlocking
+        TNT1 AAA 0 A_CustomMissile ("Brutal_FlyingBlood", 50, 0, random (0, 360), 2, random (0, 160))
+	    TNT1 A 0 A_CustomMissile ("XDeathBurnedArm", 32, 0, random (0, 360), 2, random (0, 160))
+	    TNT1 A 0 A_CustomMissile ("XDeathBurnedLeg", 32, 0, random (0, 360), 2, random (0, 160))
+	    TNT1 A 0 A_CustomMissile ("XDeathBurnedSkull", 32, 0, random (0, 360), 2, random (0, 160))
+	    TNT1 A 0 A_CustomMissile ("XDeathBurnedMeat", 32, 0, random (0, 360), 2, random (0, 160))
+	    TNT1 A 0 A_CustomMissile ("XDeathBurnedMeat2", 32, 0, random (0, 360), 2, random (0, 160))
+	    TNT1 A 0 A_CustomMissile ("XDeathBurnedMeat3", 32, 0, random (0, 360), 2, random (0, 160))
+		EXPL AAAAAA 0 A_CustomMissile ("ExplosionSmoke", 32, 0, random (0, 360), 2, random (0, 360))
+        TNT1 A 1
+		TNT1 A 0 A_SpawnItemEx("RemoveMarine",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+        TNT1 A -1
+        Stop
+
+
+		Death.GreenFire:
+        TNT1 A 0
+		TNT1 A 0 A_ChangeFlag("USESPECIAL", 0)
+		TNT1 A 0 A_ChangeFlag("FRIENDLY", 0)
+        TNT1 A 0 A_XScream
+        TNT1 A 0 A_NoBlocking
+        TNT1 AAAA 0 A_CustomMissile ("Brutal_Blood", 30, 0, random (0, 360), 2, random (0, 160))
+		
+	    TNT1 A 0 A_CustomMissile ("XDeathBurnedArm", 32, 0, random (0, 360), 2, random (0, 160))
+	    TNT1 A 0 A_CustomMissile ("XDeathBurnedLeg", 32, 0, random (0, 360), 2, random (0, 160))
+	    TNT1 A 0 A_CustomMissile ("XDeathBurnedSkull", 32, 0, random (0, 360), 2, random (0, 160))
+	    TNT1 A 0 A_CustomMissile ("XDeathBurnedMeat", 32, 0, random (0, 360), 2, random (0, 160))
+	    TNT1 A 0 A_CustomMissile ("XDeathBurnedMeat2", 32, 0, random (0, 360), 2, random (0, 160))
+	    TNT1 A 0 A_CustomMissile ("XDeathBurnedMeat3", 32, 0, random (0, 360), 2, random (0, 160))
+		
+		EXPL AAAAAAAAAAAAAAAAAAAAAAAA 0 A_CustomMissile ("GreenFlameTrails", 50, 0, random (0, 360), 2, random (0, 360))
+		XBRN AAAA 2 BRIGHT A_SpawnItem("GreenFlare",0,43)
+		TNT1 A 0 A_SpawnItemEx("RemoveMarine",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+        Stop
+
+    Death.burn:
+	TNT1 A 0
+	TNT1 A 0 A_JumpIfInTargetInventory("EnemyIsArchvile", 1, "Conversion")
+	TNT1 A 0 A_ChangeFlag("USESPECIAL", 0)
+	TNT1 A 0 A_ChangeFlag("FRIENDLY", 0)
+	 PBUR A 1
+      PBUR A 1 A_Scream
+      PBUR A 1 A_NoBlocking
+	  TNT1 A 0 A_SpawnItemEx("RemoveMarine",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+       PBUR AAAABBBBCCCC 2 A_CustomMissile ("SmallFlameTrails", 32, 0, random (0, 180), 2, random (0, 180))
+	    PBUR DDDDEEEE 2 A_CustomMissile ("SmallFlameTrails", 16, 0, random (0, 180), 2, random (0, 180))
+        PBUR EEEEE 4 A_CustomMissile ("SmallFlameTrails", 8, 0, random (0, 180), 2, random (0, 180))
+		PBUR EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE 6 A_CustomMissile ("PlasmaSmoke", 8, 0, random (0, 180), 2, random (0, 180))
+        PBUR E -1
+        Stop
+
+    Death.Fire:
+	Death.Flames:
+	Death.Burn:
+	
+	TNT1 A 0
+	
+		TNT1 A 0 A_ChangeFlag("USESPECIAL", 0)
+		TNT1 A 0 A_ChangeFlag("FRIENDLY", 0)
+        TNT1 A 0 A_PlaySound("BIGSCREA")
+		TNT1 A 0 A_JumpIfInTargetInventory("EnemyIsArchvile", 1, "Conversion")
+      BURN W 6 A_Scream
+      BURN X 6 A_NoBlocking
+	  TNT1 A 0 A_SpawnItemEx("RemoveMarine",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+       BUR2 ABCD 6 BRIGHT A_CustomMissile ("PlasmaSmoke", 8, 0, random (0, 180), 2, random (0, 180))
+       BURN FGHIJKL 6 BRIGHT A_CustomMissile ("PlasmaSmoke", 8, 0, random (0, 180), 2, random (0, 180))
+       BURN MNOPQRSTUV 6 BRIGHT A_CustomMissile ("PlasmaSmoke", 8, 0, random (0, 180), 2, random (0, 180))
+        BURN VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV 6 A_CustomMissile ("PlasmaSmoke", 8, 0, random (0, 180), 2, random (0, 180))
+        BURN V -1
+      Stop
+	  
+	  
+	  Death.ExplosiveImpact:
+		TNT1 A 0
+		TNT1 A 0 A_ChangeFlag("USESPECIAL", 0)
+		TNT1 A 0 A_ChangeFlag("FRIENDLY", 0)
+		NULL A 0 ThrustThingZ(0,30,0,1)
+		NULL AAAA 0 A_CustomMissile ("Brains1", 50, 0, random (0, 360), 2, random (0, 160))
+		NULL A 0 A_CustomMissile ("Brains2", 50, 0, random (0, 360), 2, random (0, 160))
+		NULL A 0 A_CustomMissile ("Brains3", 50, 0, random (0, 360), 2, random (0, 160))
+		NULL A 0 A_CustomMissile ("Brains4", 50, 0, random (0, 360), 2, random (0, 160))
+		NULL A 0 A_CustomMissile ("Brains5", 50, 0, random (0, 360), 2, random (0, 160))
+		NULL AAAA 0 A_CustomMissile ("SmallBrainPiece", random (45, 55), random (5, -5), random (170, 190), 2, random (0, 40))
+		NULL AAAA 0 A_CustomMissile ("SmallBrainPiece", 50, 0, random (0, 360), 2, random (0, 160))
+		NULL AA 0 A_CustomMissile ("SuperWallRedBlood", 46, 0, random (170, 190), 2, random (0, 40))
+        NULL AAAAAAAAAAA 0 A_CustomMissile ("BrainBlood", 50, 0, random (0, 360), 2, random (0, 160))
+	    NULL A 0 A_CustomMissile ("XDeathArm1", 35, 0, random (0, 360), 2, random (0, 160))
+	    NULL A 0 A_CustomMissile ("XDeath3", 40, 0, random (0, 360), 2, random (0, 160))
+	    PPOD A 0 A_SpawnItemEx("BasicMarineGib1", 0, 0, 0, 0, 0, 0, 0, SXF_TRANSFERTRANSLATION)
+        NULL AAAA 0 A_CustomMissile ("XDeath1", 40, 0, random (0, 360), 2, random (0, 160))
+		NULL A 0 A_XScream
+        XPL6 A 5
+		NULL A 0 A_NoBlocking
+        XPL6 BCDE 5
+		TNT1 A 0 A_SpawnItemEx("RemoveMarine",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+        XPL6 F -1
+        Stop
+
+    Death.HKFT:
+	Death.BHFT:
+	Death.RVFT:
+		TNT1 A 1 A_Scream
+		TNT1 A 0 A_ChangeFlag("USESPECIAL", 0)
+		TNT1 A 1 A_NoBlocking
+        TNT1 A 0 A_GiveToTarget("Curbstomp_Marine",1)
+		TNT1 A 0
+		TNT1 A 0 A_ChangeFlag("FRIENDLY", 0)
+		TNT1 A 5
+		TNT1 A 0 A_SpawnItemEx("RemoveMarine",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+		TNT1 A -1
+        Stop
+
+    Death.FatalityMarine:
+		TNT1 A 1 A_PlayerScream
+		TNT1 A 0 A_ChangeFlag("USESPECIAL", 0)
+		TNT1 A 0 A_GiveToTarget("GoFatality", 1)
+		TNT1 A 1 A_NoBlocking
+		TNT1 A 0 A_SpawnItemEx("RemoveMarine",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+        TNT1 A 0 A_GiveToTarget("Fatality_Marine",1)
+		TNT1 A -1
+        Stop
+    }
+}
+
+
+
+
+
+ACTOR CapturedMarineShotgun: CapturedMarineBase
+{
+	Translation "112:127=96:111"
+	States
+	{
+	Death.Use:
+		TNT1 A 0 A_Playsound ("LETSROCK")
+		TNT1 A 0 A_ChangeFLag ("NOPAIN", 1)
+        CAPT F 12
+        TNT1 A 0 A_NoBlocking
+		TNT1 A 0 A_GiveToTarget("NumberOfAlliesShotgun", 1)
+		TNT1 A 0 A_SpawnItemEx ("Marine_Shotgun",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+        CAPT N 1
+		TNT1 A 0 A_ChangeFLag ("SHOOTABLE", 0)
+		TNT1 A 0 A_ChangeFLag ("SOLID", 0)
+        CAPT N 0
+        Stop
+
+    }
+}
+
+
+
+ACTOR CapturedMarineMinigun: CapturedMarineBase
+{
+	Translation  "112:127=32:47", "48:79=64:79"
+	States
+	{
+	Death.Use:
+		TNT1 A 0 A_Playsound ("LETSROCK")
+		TNT1 A 0 A_ChangeFLag ("NOPAIN", 1)
+        CAPT F 12
+        TNT1 A 0 A_NoBlocking
+		TNT1 A 0 A_GiveToTarget("NumberOfAlliesMinigun", 1)
+		TNT1 A 0 A_SpawnItemEx ("Marine_Minigun",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+        CAPT N 1
+		TNT1 A 0 A_ChangeFLag ("SHOOTABLE", 0)
+		TNT1 A 0 A_ChangeFLag ("SOLID", 0)
+        CAPT N 0
+        Stop
+
+    }
+}
+
+
+
+ACTOR CapturedMarinePlasma: CapturedMarineBase
+{
+	translation "112:127=[0,128,192]:[0,0,0]"
+	States
+	{
+	Death.Use:
+		TNT1 A 0 A_Playsound ("LETSROCK")
+		TNT1 A 0 A_ChangeFLag ("NOPAIN", 1)
+        CAPT F 12
+        TNT1 A 0 A_NoBlocking
+		TNT1 A 0 A_GiveToTarget("NumberOfAlliesPLasmagun", 1)
+		TNT1 A 0 A_SpawnItemEx ("Marine_Plasmagun",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+        CAPT N 1
+		TNT1 A 0 A_ChangeFLag ("SHOOTABLE", 0)
+		TNT1 A 0 A_ChangeFLag ("SOLID", 0)
+        CAPT N 0
+        Stop
+
+    }
+}
+
+
+actor KillMe
+{
+	+NOTARGET
+Radius 10
+Height 10
+DamageType KillMe
++NOGRAVITY +NOTELEPORT +NODAMAGETHRUST
++THRUGHOST +NORADIUSDMG +NOEXTREMEDEATH
++FORCERADIUSDMG -BLOODSPLATTER +BLOODLESSIMPACT 
+PROJECTILE	+DEHEXPLOSION	+ACTIVATEMCROSS 
+States
+{
+Spawn:
+TNT1 A 0
+        TNT1 A 0 A_Explode(3,500)
+Stop
+ }
+}
+
+
+
+
+
+
+actor BodyCrash1
+{
+Radius 16
+Height 2
+DamageType Fall
++NOTELEPORT
++NODAMAGETHRUST
++FORCERADIUSDMG
+-BLOODSPLATTER
++BLOODLESSIMPACT 
+PROJECTILE
++MISSILE
+-NOGRAVITY
+-THRUACTORS
++EXPLODEONWATER
+Gravity 1.0
+Speed 0
+Damage (random (90, 95))
+States
+{
+Spawn:
+TNT1 A 1
+TNT1 A 4
+Stop
+
+Death:
+XDeath:
+TNT1 A 0 A_Explode(100,10)
+Stop
+ }
+}
+
+
+
+
+
+
+actor KillMeSmall: KillMe
+{
+States
+{
+Spawn:
+TNT1 A 0
+        TNT1 A 0 A_Explode(3,400)
+Stop
+ }
+}
+
+
+
+
+
+actor KillMeBot: KillMe
+{
+-FORCERADIUSDMG
+damagetype "KillMeBot"
+States
+{
+Spawn:
+TNT1 A 0
+        TNT1 A 0 A_Explode(3,800)
+Stop
+ }
+}
+
+ACTOR MarineSurvivor2: Marine 8756
+{
+Speed 5
+Health 6
+	States
+	{
+ Spawn:
+ PLAY A 0
+ TNT1 A 0 A_CheckSight("Spawn2")
+ PLAY A 0
+ //TNT1 A 0 A_SpawnItem ("GiantKillMe")
+ PLAY A 1 A_Chase
+ Goto See
+ 
+ Spawn2:
+ PLAY A 1
+ Goto Spawn
+	}
+}
+
+
+ACTOR MarinePunch: BaronBall
+{
+	Radius 10
+	Height 18
+	DamageType HelperMarineFatallity
+	Projectile 
+	+RANDOMIZE
+    Damage 10
+	+FORCEXYBILLBOARD
+    +THRUGHOST
+    +BLOODSPLATTER 
+	RenderStyle Add
+	Alpha 0.6
+	HitObituary "$OB_IMPHIT"
+    Obituary "$OB_IMPHIT"
+	+DONTHURTSPECIES
+
+	SeeSound "None"
+	DeathSound "none"
+	Decal "none"
+    Speed 20
+	States
+	{
+	Spawn:
+	    TNT1 A 0
+		TNT1 A 0 A_PlaySound("skeleton/swing")
+		TNT1 A 4 BRIGHT
+		Stop
+	Death:
+        TNT1 A 0 A_PlaySound("player/cyborg/fist")
+		TNT1 A 0 BRIGHT
+		Stop
+	}
+}
+
+
+
+
+ACTOR MarineGivingHealth
+{
+MONSTER
+-COUNTKILL
++SOLID
+-SHOOTABLE
++MISSILEMORE
++MISSILEEVENMORE
+Health 99999
+Radius 16
+Height 52
+Speed 0
+MeleeRange 28
+	States
+	{
+	Spawn:
+	MR8S A 1 A_Look
+	TNT1 A 0 A_CheckSight("GiveHealth")
+	TNT1 A 0 A_PlaySound("MRNGI2")
+	Goto See
+	
+	See:
+		MR8S AAAAABBBBB 5 A_Chase
+		TNT1 A 0 A_CheckSight("GiveHealth")
+		Loop
+	
+	
+	
+	Missile:
+	GiveHealth:
+	MR8S A 1 A_FaceTarget
+	TNT1 A 0 A_NoBlocking 
+	TNT1 A 0 A_SpawnItemEx("Stimpack", 30, 0)
+	TNT1 A 0 A_SpawnItem("Marine_Rifle")
+	Stop
+}
+}
+
+
+
+ACTOR BlurSphere2: BlurSphere //Replaces BlurSphere
+{
+-COUNTITEM
+	States
+	{
+	Spawn:
+		PINS A 2 Bright
+		TNT1 A 0 A_SpawnItem("CapturedMarine")
+		Stop
+	}
+}	
+
+
+Actor PoleWithNothing
+{
++NOBLOCKMAP
+Mass 99999999
+States
+{
+Spawn:
+        TNT1 A 0 A_Stop
+		TNT1 A 0 A_SpawnItem("PoleWithNothing2", 0, -40)
+        Stop
+}}
+
+
+Actor PoleWithNothing2
+{
++NOBLOCKMAP
+Mass 99999999
+States
+{
+Spawn:
+        CAPT N 1 A_Stop
+        CAPT N -1
+        Stop
+}}
+
+
+
+
+
+
+actor MonsterSightAlert
+{
+MONSTER
++THRUACTORS
+Health 1
+DamageType "Alert"
++SHOOTABLE
++NOPAIN
++MISSILE
+Radius 1
+Height 1
+States
+{
+Spawn:
+TNT1 A 1
+TNT1 A 0 
+TNT1 A 0 A_Explode(2,500, 0)
+TNT1 A 1
+Stop
+Death:
+TNT1 A 0
+Stop
+ }
+}
+
+
+
+
+
+
+
+
+Actor OrderTitle1
+{
+  Height 1
+  Radius 1
+  Mass 0
+  +Missile
+  +NoBlockMap
+  +NoGravity
+  +DontSplash
+  +FORCEXYBILLBOARD
+  +CLIENTSIDEONLY
+  +THRUACTORS
+  +GHOST
+  +THRUGHOST
+  RenderStyle Add
+  Scale 0.2
+  Speed 1
+  States
+  {
+  Spawn:
+    CMMN A 2 BRIGHT
+	CMMN AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA 1 Bright A_FadeOut(0.04)
+    Stop
+  }
+}
+
+
+Actor OrderTitle2: OrderTitle1
+{
+  States
+  {
+  Spawn:
+    CMMN B 2 BRIGHT
+	CMMN BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB 1 Bright A_FadeOut(0.04)
+    Stop
+  }
+}
+
+
+Actor OrderTitle3: OrderTitle1
+{
+  States
+  {
+  Spawn:
+    CMMN C 2 BRIGHT
+	CMMN CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC 1 Bright A_FadeOut(0.04)
+    Stop
+  }
+}
+
+
+

--- a/ExpansionChangelog.txt
+++ b/ExpansionChangelog.txt
@@ -16,6 +16,7 @@
 //	Baron.txt:						Removed the Translation property from the DeadBaron actor
 //									Changed A_SetInvulnerable to A_ChangeFlag("NOPAIN") for monster fatalities 
 //	Belphegor.txt:					Changed A_SetInvulnerable to A_ChangeFlag("NOPAIN") for monster fatalities 
+//	+CapturedMarine.txt:			Set health to 100, Normalized the DamageFactors, set DamageFactor "Use", to 1000.0, and set DamageFactor "Stealth", to 0.0
 //	DECORATE.txt:					Removed the inclusion of the Dragonslayer2.txt
 //	DEFAULTWEAPON.txt:				Added A_SetCrosshair(0) to all states that reset zoom to 1.0
 //	Demons.txt:						Added A_ChangeFlag("NOPAIN") to monster fatalities


### PR DESCRIPTION
The stealth projectile that is fired when a player presses use in the defaultweapon.txt flash state was causing captured marines to go into their pain state instead of Death.Use.