### PR TITLE
Take away Unloading in Deselect state

### DIFF
--- a/AmmoDroper.txt
+++ b/AmmoDroper.txt
@@ -22,6 +22,7 @@ ACTOR AmmoDroper : BrutalWeapon
 	Deselect:
 		TNT1 A 0
 		TNT1 A 0 A_SetCrosshair(0)
+		TNT1 A 0 A_TakeInventory("Unloading", 1)
 		TNT1 AAAAAAAAA 0 A_Lower
 		TNT1 AAAAAA 1 A_Lower
 		

--- a/Axe.txt
+++ b/Axe.txt
@@ -122,10 +122,10 @@ ACTOR BrutalAxe : BrutalWeapon
 		AXEG A 0 A_Takeinventory("PowerBlueBloodOnVisor",1)
 		AXEG A 0 A_Takeinventory("PowerGreenBloodOnVisor",1)
 		AXEG A 0 A_Takeinventory("HasCutingWeapon",1)
+		AXEG A 0 A_TakeInventory("TossGrenade", 1)
+		TNT1 A 0 A_TakeInventory("Unloading", 1)
 		A12G A 0 A_SetCrosshair(0)
 		TNT1 AAAAAAAAAAAAAAAAAA 0 A_Lower
-		AXEG A 0 A_Takeinventory("HasCutingWeapon",1)
-		AXEG A 0 A_TakeInventory("TossGrenade", 1)
 		TNT1 A 1 A_Lower
 		Wait
 		

--- a/BFG.txt
+++ b/BFG.txt
@@ -104,8 +104,9 @@ ACTOR BIG_FUCKING_GUN : BrutalWeapon
 		Goto Ready
 		
 	Deselect:
-	    TNT1 AAAAAAAAAAAAAAAAAA 0 A_Lower
 		BFGN A 0 A_TakeInventory("TossGrenade", 1)
+		TNT1 A 0 A_TakeInventory("Unloading", 1)
+	    TNT1 AAAAAAAAAAAAAAAAAA 0 A_Lower
 		BFGN A 1 A_Lower
 		Loop
 		

--- a/BFG10k.txt
+++ b/BFG10k.txt
@@ -64,10 +64,6 @@ Actor BFG10k : BrutalWeapon
 		BG2G A 0 A_JumpIfInventory("IsRunning",1,"CheckSprint")
 		Loop
 	
-  Deselect:
-    BG2G E 1 BRIGHT A_Lower
-    Loop
-	
   Select:
 	BG2G A 0 A_Giveinventory("GoSpecial",1)
   	BG2G A 0 A_Takeinventory("FistsSelected",1)
@@ -189,8 +185,9 @@ Actor BFG10k : BrutalWeapon
 		Goto Ready
 		
 	Deselect:
-	    TNT1 AAAAAAAAAAAAAAAAAA 0 A_Lower
 		BG2G A 0 A_TakeInventory("TossGrenade", 1)
+		TNT1 A 0 A_TakeInventory("Unloading", 1)
+		TNT1 AAAAAAAAAAAAAAAAAA 0 A_Lower
 		BG2G A 1 BRIGHT A_Lower
 		Loop	
   }

--- a/ExpansionChangelog.txt
+++ b/ExpansionChangelog.txt
@@ -9,13 +9,17 @@
 //	Sprites/Monsters folder:		Added SMGGuy idle and LabGuy with the correct axe sprites from Dox778
 //	Sprites/Weapons folder:			Removed all Dragonslayer sprites
 //	AmmoDropper.txt:				Added A_Setcrosshair(41) to Select and A_Setcrosshair(0) to Deselect states
+//									Added TNT1 A 0 A_TakeInventory("Unloading", 1) to Deselect state
 //	ArchVile.txt:					Added -SOLID flag to DyingArchvileNoArm
 //	Artifact.txt:					Reverted the conditional flare spawns when out of the player's sight
 //	Assaultshotgun.txt:				Added A_Setcrosshair(41) Altfire and A_SetCrosshair(0) to all states that reset zoom to 1.0
 //	Axe.txt:						Added A_Setcrosshair(41) to Select and A_Setcrosshair(0) to Deselect states
+//									Added TNT1 A 0 A_TakeInventory("Unloading", 1) to Deselect state
 //	Baron.txt:						Removed the Translation property from the DeadBaron actor
 //									Changed A_SetInvulnerable to A_ChangeFlag("NOPAIN") for monster fatalities 
 //	Belphegor.txt:					Changed A_SetInvulnerable to A_ChangeFlag("NOPAIN") for monster fatalities 
+//	BFG.txt:						Added TNT1 A 0 A_TakeInventory("Unloading", 1) to Deselect state
+//	BFG10K.txt:						Added TNT1 A 0 A_TakeInventory("Unloading", 1) to Deselect state
 //	+CapturedMarine.txt:			Set health to 100, Normalized the DamageFactors, set DamageFactor "Use", to 1000.0, and set DamageFactor "Stealth", to 0.0
 //	DECORATE.txt:					Removed the inclusion of the Dragonslayer2.txt
 //	DEFAULTWEAPON.txt:				Added A_SetCrosshair(0) to all states that reset zoom to 1.0
@@ -26,24 +30,35 @@
 //	DyingGuys.txt:					Change actors who were inheriting from the "alive" monsters to instead inherit from their generic dying monster (execpt for the armless Pinky)
 //									Set all dying actors to -SOLID
 //	Fire.txt:						Reverted the conditional flare and particle spawns when out of the player's sight
+//	FlameCannon.txt:				Added TNT1 A 0 A_TakeInventory("Unloading", 1) to Deselect state
+//	FlameThrower.txt:				Added TNT1 A 0 A_TakeInventory("Unloading", 1) to Deselect state
 //	GLDEFS.txt:						Removed the vert and horizontal Slayermissile entries for the Dragonslayer
+//	Grenades.txt:					Added TNT1 A 0 A_TakeInventory("Unloading", 1) to Deselect state
 //	Health2.txt:					Reverted the conditional flare spawns when out of the player's sight
+//	HellishMissile.txt:				Added TNT1 A 0 A_TakeInventory("Unloading", 1) to Deselect state
 //	Knight.txt:						Changed A_SetInvulnerable to A_ChangeFlag("NOPAIN") for monster fatalities 
 //	Lamps.txt:						Reverted the conditional flare spawns when out of the player's sight
 //	Machinegun.txt:					Added lines to check for AmmoRocket first before allowing a jump to ReloadGrenade in the Reload state
+//									Added TNT1 A 0 A_TakeInventory("Unloading", 1) to Deselect state
 //	MapSpecificDec.txt:				Reverted the conditional flare spawns when out of the player's sight
+//	Minigun.txt:					Added TNT1 A 0 A_TakeInventory("Unloading", 1) to Deselect state
+//	Melee.txt:						Added TNT1 A 0 A_TakeInventory("Unloading", 1) to Deselect state
 //	MP40.txt:						Added A_Setcrosshair(41) Altfire and A_SetCrosshair(0) to all states that reset zoom to 1.0
+//									Added TNT1 A 0 A_TakeInventory("Unloading", 1) to HitlersBuzzsaw Deselect state
+//	NukeLauncher.txt:				Added TNT1 A 0 A_TakeInventory("Unloading", 1) to Deselect state
 //	Railgun.txt:					Added A_Setcrosshair(41) Altfire and A_SetCrosshair(0) to all states that reset zoom to 1.0
 //	Revenant.txt:					Notated-out the A_ChangeFlag("Shootable") for monster fatalities 
 //	Rifle.txt:						Added A_Setcrosshair(41) Altfire and A_SetCrosshair(0) to all states that reset zoom to 1.0
 //	RocketLauncher.txt:				Added A_Setcrosshair(41) Altfire and A_SetCrosshair(0) to all states that reset zoom to 1.0
 //									Added a GoTaunt state like the Railgun so that PowerLightAmp will be removed if jumping to Taunt from a zoomed state.
 //	Saw.txt:						Added A_Setcrosshair(41) to Select and A_Setcrosshair(0) to Deselect states
+//									Added TNT1 A 0 A_TakeInventory("Unloading", 1) to Deselect state
 //	Sergeants.txt:					Changed the SMGGuy's Spawn, Stand, and Idle frames to now use the new sprites from Dox778
 //	Shotgun.txt:					Added A_Setcrosshair(41) Altfire and A_SetCrosshair(0) to all states that reset zoom to 1.0
 //									Set the DoKickReloading state to jump to FinishedInsertingShells instead of back to InsertingShells wasting ammo
 //	SubMachinegun.txt:				Added A_Setcrosshair(41) Altfire and A_SetCrosshair(0) to all states that reset zoom to 1.0
 //	Torches.txt:					Reverted the conditional flare and particle spawns when out of the player's sight
+//	Unmaker.txt:					Added TNT1 A 0 A_TakeInventory("Unloading", 1) to Deselect state
 //	Volcabus.txt:					Adjusted radius and height to match the monsters increased size from previous edits.
 //									Changed probability of jumping to the Suffer state in Death.Massacre to 128 (rarely happens)
 //	WeaponSpawners.txt:				Removed the Dragonslayer from the ChainsawSpawner

--- a/FlameCannon.txt
+++ b/FlameCannon.txt
@@ -100,6 +100,7 @@ ACTOR FlameCannon : BrutalWeapon
 	Deselect:
 	    FLMG A 0 A_StopSound(CHAN_WEAPON)
 		FLMG A 0 A_TakeInventory("TossGrenade", 1)
+		TNT1 A 0 A_TakeInventory("Unloading", 1)
 		FLMG A 1 A_Lower
 		Loop
 	Select:

--- a/Flamethrower.txt
+++ b/Flamethrower.txt
@@ -103,6 +103,7 @@ ACTOR Flamethrower2 : BrutalWeapon
 	Deselect:
 	    FLMT A 0 A_StopSound(CHAN_WEAPON)
 		FLMT A 0 A_TakeInventory("TossGrenade", 1)
+		TNT1 A 0 A_TakeInventory("Unloading", 1)
 		FLMT A 1 BRIGHT A_Lower
 		Loop
 	Select:

--- a/Grenades.txt
+++ b/Grenades.txt
@@ -45,6 +45,7 @@ ACTOR HandGrenades : BrutalWeapon
 	Deselect:
 		TNT1 A 0
 		TNT1 A 0 A_JumpIfInventory("FiredGrenade", 1, "DropGrenade")
+		TNT1 A 0 A_TakeInventory("Unloading", 1)
 		TNT1 A 1 A_Lower
 		Wait
 	

--- a/HellishMissile.txt
+++ b/HellishMissile.txt
@@ -96,8 +96,9 @@ ACTOR HellishMissileLauncher : BrutalWeapon
 		Goto Ready
 		
 	Deselect:
-		RVCG A   1 A_Lower
 		RVCG A 0 A_TakeInventory("TossGrenade", 1)
+		TNT1 A 0 A_TakeInventory("Unloading", 1)
+		RVCG A 1 A_Lower
 		Loop
 	Select:
 		RVCG A 0 A_Giveinventory("GoSpecial",1)

--- a/Machinegun.txt
+++ b/Machinegun.txt
@@ -118,6 +118,7 @@ ACTOR Machinegun : BrutalWeapon
 			MGN1 A 0 A_TakeInventory("TossGrenade", 1)
 			MGN1 A 0 A_Takeinventory("HeavyAutomaticWeapon",1)
 			MGN1 A 0 A_TakeInventory("RandomHeadExploder", 1)
+			TNT1 A 0 A_TakeInventory("Unloading", 1)
 			MGN1 A 0 SetPlayerProperty(0,0,0)
 			MGS1 DCBA 1
 			TNT1 AAAAAAAAAAAAAAAAAA 0 A_Lower

--- a/Melee.txt
+++ b/Melee.txt
@@ -270,6 +270,7 @@ ACTOR Melee_Attacks : BrutalWeapon Replaces Fist
 		
 		TNT1 A 0 A_TakeInventory("TossGrenade", 1)
 		TNT1 A 0 A_Takeinventory("FistsSelected",1)
+		TNT1 A 0 A_TakeInventory("Unloading", 1)
 		//TNT1 A 0 A_jumpifinventory("LostSoulFatality",1,"KillLS")
 		TNT1 A 0 A_JumpIfInventory("HasBarrel",1,"FireBarrel")
 		TNT1 A 0 A_JumpIfInventory("GrabbedAZombieman",1,"ThrowZombieman")

--- a/Minigun.txt
+++ b/Minigun.txt
@@ -124,6 +124,7 @@ ACTOR MiniGun : BrutalWeapon
 			CHAG A 0 A_TakeInventory("TossGrenade", 1)
 			CHAG A 0 A_Takeinventory("HeavyAutomaticWeapon",1)
 			CHAG A 0 A_TakeInventory("RandomHeadExploder", 1)
+			TNT1 A 0 A_TakeInventory("Unloading", 1)
 			CHAG A 0 SetPlayerProperty(0,0,0)
 			CHGS DCBA 1
 			TNT1 AAAAAAAAAAAAAAAAAA 0 A_Lower

--- a/Mp40.txt
+++ b/Mp40.txt
@@ -493,6 +493,7 @@ ACTOR HitlersBuzzsaw : BrutalWeapon
 		Goto Ready 
 		
 	Deselect:
+		TNT1 A 0 A_TakeInventory("Unloading", 1)
 		HBUS A 1 A_Lower
 		Loop
 	Select:

--- a/NukeLauncher.txt
+++ b/NukeLauncher.txt
@@ -108,6 +108,7 @@ ACTOR NukeLauncher : BrutalWeapon 7452
 	Deselect:
 	    NKLG A 0 A_StopSound(CHAN_WEAPON)
 		NKLG A 0 A_TakeInventory("TossGrenade", 1)
+		TNT1 A 0 A_TakeInventory("Unloading", 1)
 		NKLG A 1 A_Lower
 		Loop
 	Select:

--- a/Saw.txt
+++ b/Saw.txt
@@ -73,6 +73,7 @@ states
 		AXEG A 0 A_Takeinventory("PowerBlueBloodOnVisor",1)
 		AXEG A 0 A_Takeinventory("PowerGreenBloodOnVisor",1)
 		SAWG A 0 A_Takeinventory("HasCutingWeapon",1)
+		TNT1 A 0 A_TakeInventory("Unloading", 1)
 		SAWG A 0 A_StopsoundEx("Weapon")
 		TNT1 A 0 A_SetCrosshair(0)
 		SAWG A 0 A_Lower

--- a/Unmaker.txt
+++ b/Unmaker.txt
@@ -116,10 +116,11 @@ ACTOR Unmaker : BrutalWeapon
 		Goto Ready
 		
 	Deselect:
-		UNHG A   1 A_Lower
 		UNHG A 0 A_StopSOund(1)
 		UNHG A 0 A_StopSOund(6)
 		UNHG A 0 A_TakeInventory("TossGrenade", 1)
+		TNT1 A 0 A_TakeInventory("Unloading", 1)
+		UNHG A 1 A_Lower
 		Loop
 	Select:
 		UNHG A 0 A_Giveinventory("GoSpecial",1)


### PR DESCRIPTION
Added TNT1 A 0 A_TakeInventory("Unloading", 1) to the Deselect states of all weapons that do not have a Unload function to prevent unloading from triggering when an unload-able weapon is later selected.