### PR TITLE
Made pistol hold fire as fast as fast-clicking for convenience in combat

### DIFF
--- a/Pistol.txt
+++ b/Pistol.txt
@@ -458,7 +458,7 @@ ACTOR BrutalPistol : BrutalWeapon
 		
 	NoDual:
 		PIST F 1
-		PIST F 0 A_Print("You can't dual wield pistols when playing in Tactical Mode. Real operators never try to look cool in a firefight.",1)
+		PIST F 0 A_Print("You can't dual wield pistols when playing in Tactical Mode.",1)
 		Goto Ready	
 	}
 }

--- a/Pistol.txt
+++ b/Pistol.txt
@@ -458,7 +458,7 @@ ACTOR BrutalPistol : BrutalWeapon
 		
 	NoDual:
 		PIST F 1
-		PIST F 0 A_Print("You can't dual wield pistols when playing in Tactical Mode.",1)
+		PIST F 0 A_Print("You can't dual wield pistols when playing in Tactical Mode. Real operators never try to look cool in a firefight.",1)
 		Goto Ready	
 	}
 }

--- a/Pistol.txt
+++ b/Pistol.txt
@@ -166,11 +166,11 @@ ACTOR BrutalPistol : BrutalWeapon
 		PIST D 1
 		PIST F 0 A_JumpIfInventory("Reloading",1,"Reload")
 		PIST F 0 A_JumpIfInventory("TossGrenade",1,"TossGrenade")
-		PIST F 3 A_WeaponReady(WRF_NOBOB | WRF_ALLOWRELOAD)
+		PIST F 2 A_WeaponReady(WRF_NOBOB | WRF_ALLOWRELOAD)
+		PIST F 0 A_REfire
 		PIST F 0 A_JumpIfInventory("Reloading",1,"Reload")
 		PIST F 0 A_JumpIfInventory("TossGrenade",1,"TossGrenade")
 		PIST F 3 A_WeaponReady(WRF_NOBOB | WRF_ALLOWRELOAD)
-		PIST F 0 A_REfire
 		Goto Ready
 		
 	Fire2:


### PR DESCRIPTION
For instance, if one fires a rifle and switches to pistol in non-tactical mode, one can fail to react and switch from holding the fire button to fast-clicking. I made hold and fast-click even.