### PR TITLE
Marine Polishing

### DIFF
--- a/ExpansionChangelog.txt
+++ b/ExpansionChangelog.txt
@@ -18,6 +18,8 @@
 //	HellishMissile.txt:				Added TNT1 A 0 A_TakeInventory("Reloading", 1) to Deselect state
 //	Machinegun.txt:					Fixed PickupMessage
 //									Added TNT1 A 0 A_TakeInventory("Reloading", 1) to Deselect state
+//	MARINES.txt:					Polishing of the Marine's actor properties and flags
+//									Reordered the Active state to prevent double-marine spawns on activation online
 //	Melee.txt:						Added TNT1 A 0 A_TakeInventory("Reloading", 1) to Deselect state
 //	MENUDEF.txt:					Updated with additions from Shockwave_508
 //	Minigun.txt:					Fixed PickupMessage
@@ -25,6 +27,7 @@
 //	Mp40.txt:						Added TNT1 A 0 A_TakeInventory("Reloading", 1) to Deselect state of Buzzsaw
 //	NukeLauncher.txt:				Added TNT1 A 0 A_TakeInventory("Reloading", 1) to Deselect state
 //	Plasma.txt:						Fixed PickupMessage
+//	PUFF.txt:						Added Species "Marines" and +MTHRUSPECIES to MeleePuff and HitPuff so that marines won't block the player's shots
 //	Railgun.txt:					Fixed PickupMessage
 //	Saw.txt:						Added TNT1 A 0 A_TakeInventory("Reloading", 1) to Deselect state
 //	SSG.txt:						Added A_TakeInventory("SSGAlt",1) to FinishUnload state 

--- a/ExpansionChangelog.txt
+++ b/ExpansionChangelog.txt
@@ -27,7 +27,6 @@
 //	Mp40.txt:						Added TNT1 A 0 A_TakeInventory("Reloading", 1) to Deselect state of Buzzsaw
 //	NukeLauncher.txt:				Added TNT1 A 0 A_TakeInventory("Reloading", 1) to Deselect state
 //	Plasma.txt:						Fixed PickupMessage
-//	PUFF.txt:						Added Species "Marines" and +MTHRUSPECIES to MeleePuff and HitPuff so that marines won't block the player's shots
 //	Railgun.txt:					Fixed PickupMessage
 //	Saw.txt:						Added TNT1 A 0 A_TakeInventory("Reloading", 1) to Deselect state
 //	SSG.txt:						Added A_TakeInventory("SSGAlt",1) to FinishUnload state 

--- a/MARINES.txt
+++ b/MARINES.txt
@@ -1,0 +1,1865 @@
+ACTOR PrePlacedMarine Replaces MarinePistol
+{
+MONSTER
+Height 56
+Radius 16
+-COUNTKILL
+    States
+	{
+	Spawn:
+	PLAY A 1
+	TNT1 A 0 A_NoBlocking
+	PLAY A 1
+	TNT1 A 0 A_SpawnItemEx ("Marine",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+	Stop
+    }
+}
+
+ACTOR Marine
+{
+    Radius 16
+    Height 56
+	MONSTER
+	-SHOOTABLE
+	-COUNTKILL
+	-FRIENDLY
+	+THRUACTORS
+	States
+    {
+    Spawn:
+	    PLAY A 10 
+		PLAY A 1 A_CheckSight("DontSpawn")
+		TNT1 A 0 A_Chase
+		TNT1 A 0 A_Look
+	See:	
+		TNT1 A 0 A_GiveToTarget("NumberOfAllies", 1)
+		TNT1 A 0 A_SpawnItemEx ("Marine_Rifle",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+        Stop
+	
+	DontSpawn:
+	    PLAY A 1
+		Goto Spawn	
+    }
+}
+
+ACTOR RandomMarine: RedTorch
+{
+    Radius 16
+    Height 56
+	-SHOOTABLE
+	States
+    {
+    Spawn:
+	    PLAY A 1 
+		PLAY A 1 A_CheckSight("DontSpawn")
+		TNT1 A 0 A_Chase
+		TNT1 A 0 A_Look
+	See:	
+		TNT1 A 0
+		TNT1 A 0 A_Jump(96, "See1", "See2")
+		TNT1 A 0 A_Jump(96, "See3")
+		TNT1 A 0 A_Jump(64, "See4")
+		//TNT1 A 0 A_Jump(32, "See5", "See6")
+		TNT1 A 0 A_Jump(255, "See1", "See2")
+		Goto See1
+		
+	See1:	
+		TNT1 A 0 A_SpawnItemEx ("PrePLacedMarine",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+        Stop
+	
+	See2:	
+		TNT1 A 0 A_SpawnItemEx ("MarineShotgun",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+        Stop
+		
+	See3:	
+		TNT1 A 0 A_SpawnItemEx ("MarineChaingun",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+        Stop
+	
+	See4:	
+		TNT1 A 0 A_SpawnItemEx ("MarinePlasma",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+        Stop
+		
+	See5:	
+		TNT1 A 0 A_SpawnItemEx ("MarineRocket",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+        Stop	
+		
+	See6:	
+		TNT1 A 0 A_SpawnItemEx ("MarineBFG",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+        Stop		
+		
+	DontSpawn:
+	    PLAY A 1
+		Goto Spawn
+    }
+}
+
+ACTOR Marine_Fist: PrePlacedMarine Replaces MarineFist
+{
+Health 100
+}
+
+ACTOR Marine_SSG: PrePlacedMarine Replaces MarineSSG
+{
+Health 100
+}
+
+ACTOR Marine_Rifle: SwitchableDecoration
+{
+	Game Doom
+	Health 100
+	PainChance 255
+	Damagefactor "Avoid", 0.0	Damagefactor "BHFTOnBarrel", 0.0	Damagefactor "Blood", 0.0
+	Damagefactor "CancelTeleportFog", 0.0	Damagefactor "CauseWaterSplash", 0.0	Damagefactor "Crush", 10.0
+	Damagefactor "Cut", 0.0	Damagefactor "Extremepunches", 0.0	Damagefactor "Fatality", 0.0
+	Damagefactor "FriendBullet", 0.0	Damagefactor "GibRemoving", 0.0	Damagefactor "Glass", 0.1
+	Damagefactor "HangingHook", 0.0	Damagefactor "Head", 0.0	Damagefactor "HeadKick", 0.0
+	Damagefactor "HelperMarineFatallity", 0.0	Damagefactor "KillMe", 0.0	Damagefactor "Leg", 0.0
+	Damagefactor "LowKick", 0.0	Damagefactor "MonsterKnocked", 0.0	Damagefactor "PussyGrab", 0.0
+	Damagefactor "Repair", 0.0	Damagefactor "RevenantHitStomach", 0.0	Damagefactor "Saw", 0.0
+	Damagefactor "Slide", 0.0	Damagefactor "SpawnMarine", 0.0	Damagefactor "Taunt", 0.0
+	Damagefactor "TeleportRemover", 0.0
+	Speed 3
+	FastSpeed 22
+	Species "Marines"
+	Activation THINGSPEC_Activate
+	Radius 16
+	Height 56
+	Mass 130
+	MaxStepHeight 56
+	MaxDropOffHeight 112
+	ActiveSound "none"
+	AttackSound "none"
+	DeathSound "DSMADTH"
+	PainSound "*pain"
+	SeeSound "None"
+	Scale 1.0
+	Translation "112:127=117:127"
+	BloodType "Player_Blood", "Player_BloodSaw", "Player_Blood"
+	Obituary "%o has been gunned down by a Marine."
+	MaxTargetRange 2048
+	Monster
+	DropItem "RifleDrop"
+	+FLOORCLIP
+	+QUICKTORETALIATE
+    +DONTHARMCLASS
+    +FIXMAPTHINGPOS 
+	+LOOKALLAROUND
+	+PUSHABLE
+	+SLIDESONWALLS
+	-CANNOTPUSH
+	-COUNTKILL
+	+DONTSPLASH
+	+NORADIUSDMG
+	+USESPECIAL
+	+THRUSPECIES
+	+DONTHARMSPECIES
+	+NOTAUTOAIMED
+	+NOBLOCKMONST
+	States
+	{
+	Active:
+		TNT1 A 0 A_ChangeFlag("NOBLOCKMAP", 1)
+		MR7S A 30
+		TNT1 A 0 A_SpawnItemEx ("RifleMarineGuarding",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+		TNT1 A 0 A_CustomMissile ("OrderTitle2", 50, 0, 0, 2, 90)
+		TNT1 A 0 A_PlaySound("MarineGuard", 2)
+		Stop
+		
+	Spawn:
+		TNT1 A 0
+		TNT1 A 0 A_GiveInventory("TargetIsAMarine")
+		PLAY A 1 A_Look
+		Goto See
+	
+	ForgetTarget:
+		TNT1 A 0 A_ClearTarget
+		Goto See
+	
+	See:
+		TNT1 A 0 A_JumpIfInventory("ZombiemanFatality3", 1, "FatalityZombieman")
+		TNT1 A 0 A_JumpIfInventory("ImpFatality3", 1, "FatalityImp")
+		TNT1 A 0 A_JumpIfInventory("SergeantFatality", 1, "FatalitySergeant")
+		TNT1 A 0 A_JumpIfInventory("RevenantFatality", 1, "FatalityRevenant")
+		NULL A 0 A_JumpIfInventory("ComandoFatality", 1, "FatalityComando")
+		TNT1 A 0 A_ChangeFlag("NODROPOFF", 0)	
+		TNT1 A 0 A_ChangeFLag("FRIENDLY", 1)
+		TNT1 A 0 A_JumpIfInTargetInventory("TargetIsAMarine", 1, "FollowPLayer")//
+	
+	TNT1 A 0 A_ChangeFlag("MISSILEMORE", 1)
+		TNT1 A 0 A_ChangeFlag("MISSILEEVENMORE", 1)
+		TNT1 A 0 A_Recoil(-1)
+		TNT1 A 0 A_JumpIfInTargetInventory("TargetIsAMarine", 1, "FollowPLayer")//
+		PLAY AA 1 A_Chase
+		TNT1 A 0 A_ChangeFlag("FASTER", 0)
+		TNT1 A 0 A_Recoil(-1)
+		TNT1 A 0 A_JumpIfInTargetInventory("TargetIsAMarine", 1, "FollowPLayer")//
+		PLAY BB 1 A_Chase
+		TNT1 A 0 A_Recoil(-1)
+		TNT1 A 0 A_JumpIfInTargetInventory("TargetIsAMarine", 1, "FollowPLayer")//
+		PLAY BB 1 A_Chase
+		TNT1 A 0 A_ChangeFLag("FRIENDLY", 0)
+		TNT1 A 0 A_Recoil(-1)
+		TNT1 A 0 A_JumpIfInTargetInventory("TargetIsAMarine", 1, "FollowPLayer")//
+		PLAY CC 1 A_Chase
+		TNT1 A 0 A_ChangeFLag("FRIENDLY", 1)
+		TNT1 A 0 A_Recoil(-1)
+		TNT1 A 0 A_JumpIfInTargetInventory("TargetIsAMarine", 1, "FollowPLayer")//
+		PLAY CC 1 A_Chase
+		TNT1 A 0 A_Recoil(-1)
+		TNT1 A 0 A_JumpIfInTargetInventory("TargetIsAMarine", 1, "FollowPLayer")//
+		PLAY DD 1 A_Chase
+		TNT1 A 0 A_Recoil(-1)
+		TNT1 A 0 A_JumpIfInTargetInventory("TargetIsAMarine", 1, "FollowPLayer")//
+		PLAY DD 1 A_Chase
+		TNT1 A 0 A_Recoil(-1)
+		TNT1 A 0 A_CheckSight("ForgetTarget")
+		TNT1 A 0 A_JumpIfInTargetInventory("TargetIsAMarine", 1, "FollowPLayer")//
+		TNT1 A 0 A_CheckSight("FollowPLayer")
+		TNT1 A 0 A_ChangeFLag("FRIENDLY", 0)
+		TNT1 A 0 A_ChangeFlag("SHOOTABLE", 0)
+		
+		PLAY AA 1 A_Chase
+		TNT1 A 0 A_Recoil(-1)
+		TNT1 A 0 A_JumpIfCloser(200, "Waits")
+		TNT1 A 0 A_CheckSight("CheckIfPlayerSee")
+		
+		PLAY BB 1 A_Chase
+		TNT1 A 0 A_Recoil(-1)
+		TNT1 A 0 A_JumpIfInTargetInventory("IsPlayer", 1, "FollowPlayer")
+		TNT1 A 0 A_JumpIfCloser(200, "Waits")
+		TNT1 A 0 A_CheckSight("CheckIfPlayerSee")
+		
+		PLAY CC 1 A_Chase
+		TNT1 A 0 A_Recoil(-1)
+		TNT1 A 0 A_JumpIfInTargetInventory("IsPlayer", 1, "FollowPlayer")
+		TNT1 A 0 A_JumpIfCloser(200, "Waits")
+		TNT1 A 0 A_CheckSight("CheckIfPlayerSee")
+		
+		PLAY DD 1 A_Chase
+		TNT1 A 0 A_Recoil(-1)
+		
+		TNT1 A 0 A_JumpIfInTargetInventory("IsPlayer", 1, "FollowPlayer")
+		TNT1 A 0 A_JumpIfCloser(200, "Waits")
+		TNT1 A 0 A_CheckSight("CheckIfPlayerSee")
+	
+	TNT1 A 0 A_JumpIfCloser(200, "Waits")
+		TNT1 A 0 A_JumpIfInTargetInventory("IsPlayer", 1, "FollowPlayer")
+		Goto See
+	BecomeEnemy23:
+		PLAY A 1
+		TNT1 A 0 A_ClearTarget
+		TNT1 A 0 A_ChangeFlag("SHOOTABLE", 0)
+		TNT1 A 0 A_ChangeFLag("FRIENDLY", 0)
+		Goto FollowPlayer
+		
+	FollowPlayer:
+	    TNT1 A 0 A_ChangeFlag("FRIENDLY", 0)
+		TNT1 A 0 A_ChangeFlag("FASTER", 1)
+		TNT1 A 0 A_ChangeFlag("SHOOTABLE", 0)
+	    TNT1 A 0 A_JumpIfCloser(150, "Waits")
+		TNT1 A 0 A_ChangeFlag("MISSILEMORE", 0)
+		TNT1 A 0 A_ChangeFlag("MISSILEEVENMORE", 0)
+		PLAY A 1 A_Chase
+		TNT1 A 0 A_Recoil(-1)
+		TNT1 A 0 A_Recoil(-1)
+		PLAY AA 1 A_Chase
+		TNT1 A 0 A_Recoil(-1)
+		PLAY BB 1 A_Chase
+		TNT1 A 0 A_Recoil(-1)
+		PLAY BB 1 A_Chase
+		TNT1 A 0 A_Recoil(-1)
+		PLAY CC 1 A_Chase
+		TNT1 A 0 A_Recoil(-1)
+		PLAY CC 1 A_Chase
+		TNT1 A 0 A_Recoil(-1)
+		PLAY DD 1 A_Chase
+		TNT1 A 0 A_Recoil(-1)
+		PLAY DD 1 A_Chase
+		TNT1 A 0 A_Recoil(-1)
+		
+		PLAY AA 1 A_Chase
+		TNT1 A 0 A_Recoil(-1)
+		PLAY BB 1 A_Chase
+		TNT1 A 0 A_Recoil(-1)
+		PLAY BB 1 A_Chase
+		TNT1 A 0 A_Recoil(-1)
+		PLAY CC 1 A_Chase
+		TNT1 A 0 A_CheckSight("CheckIfPlayerSee")
+		TNT1 A 0 A_Recoil(-1)
+		PLAY CC 1 A_Chase
+		TNT1 A 0 A_Recoil(-1)
+		PLAY DD 1 A_Chase
+		TNT1 A 0 A_Recoil(-1)
+		PLAY DD 1 A_Chase
+		TNT1 A 0 A_Recoil(-1)
+		
+		TNT1 A 0 A_ChangeFlag("FRIENDLY", 1)
+		TNT1 A 0 A_JumpIfTargetInLOS("See")
+		TNT1 A 0 A_ChangeFlag("FRIENDLY", 0)
+	
+	TNT1 A 0 A_CheckSight("CheckIfPlayerSee")
+		Loop
+	
+	CheckRangeToWait:
+		TNT1 A 0
+		TNT1 A 0 A_JumpIfCloser(150, "Waits")
+		Goto FollowPLayer
+	
+	CheckIfPlayerSee:
+		TNT1 A 0
+		PLAY AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA 0 A_FastChase
+		TNT1 A 0 A_ChangeFlag("SHOOTABLE", 0)
+		TNT1 A 0 A_ChangeFLag("FRIENDLY", 0)
+		////TNT1 A 0 Thing_Hate(94, 0, 0)
+		TNT1 A 0 A_JumpIfCloser(800, 2)
+		Goto Pathfind
+		TNT1 AAA 0
+		Goto FollowPlayer
+	
+	Pathfind:
+		TNT1 A 0
+		TNT1 A 0 A_ChangeFLag("FRIENDLY", 0)
+		TNT1 A 0 A_JumpIFInTargetInventory("IsPLayer", 1, 1)
+		Goto FollowPLayer
+		//TNT1 A 1 A_Chase("", "")
+	TNT1 A 0 A_ChangeFlag("SHOOTABLE", 0)
+		TNT1 A 0 A_ChangeFlag("NOBLOCKMAP", 1)
+		TNT1 A 0 A_ChangeFlag("NOCLIP", 1)
+		TNT1 A 0 A_ChangeFlag("SOLID", 0)
+		TNT1 A 0 A_Noblocking
+		TNT1 A 0 A_SpawnItemEx ("Marine1Pathfinder",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+		Stop
+	
+	Waits:
+		MARN D 1
+		TNT1 A 0 A_JumpIfInTargetInventory("IsPlayer", 1, 2)
+		TNT1 A 0 A_ClearTarget
+		Goto See
+		TNT1 A 0 A_ChangeFlag("FRIENDLY", 0)
+		TNT1 A 0 A_ChangeFlag("MISSILEMORE", 1)
+		TNT1 A 0 A_ChangeFlag("MISSILEEVENMORE", 1)
+		TNT1 A 0 A_ChangeFlag("SHOOTABLE", 0)
+		TNT1 A 0 A_ChangeFlag("SOLID", 0)
+		TNT1 A 0 A_JumpIfInTargetInventory("TargetIsAMarine", 1, "BecomeEnemy23")
+		TNT1 A 0 A_Jump(32, "Waits2")
+		TNT1 A 0 A_Jump(32, "Waits3")
+		
+		MARN D 8 A_Stop
+		MARN D 8 A_Stop
+		TNT1 A 0 A_Stop
+		TNT1 A 0 A_CheckSight("FollowPlayer")
+		TNT1 A 0 A_ChangeFLag("FRIENDLY", 1)
+		TNT1 A 0 A_ClearTarget
+		
+		TNT1 A 0 A_ChangeFlag("SHOOTABLE", 1)
+		MARN D 0 A_Look
+		TNT1 A 0 A_ChangeFLag("FRIENDLY", 0)
+		TNT1 A 0 A_ChangeFlag("SHOOTABLE", 0)
+		MARN D 1 A_LookEx(0, 0, 0, 0, 0, "FollowPlayer")
+		TNT1 A 0 A_CheckSIght("FollowPlayer")
+		TNT1 A 0 A_ChangeFlag("SHOOTABLE", 1)
+		TNT1 A 0 A_JumpIfCloser(200, "Waits")
+		Goto FollowPlayer
+	
+	Waits2:
+		TNT1 A 0 A_SetAngle(random(90, -90) + angle)
+		MARN D 8 A_Stop
+		TNT1 A 0 A_PlaySound("MRNWT", 2)
+		MARN D 8 A_Stop
+		TNT1 A 0 A_CheckSight("FollowPlayer")
+		TNT1 A 0 A_ChangeFLag("FRIENDLY", 1)
+		TNT1 A 0 A_ClearTarget
+		
+		TNT1 A 0 A_ChangeFlag("SHOOTABLE", 1)
+		MARN D 0 A_Look
+		TNT1 A 0 A_ChangeFLag("FRIENDLY", 0)
+		TNT1 A 0 A_ChangeFlag("SHOOTABLE", 0)
+		MARN D 1 A_LookEx(0, 0, 0, 0, 0, "FollowPlayer")
+		TNT1 A 0 A_CheckSIght("FollowPlayer")
+		TNT1 A 0 A_ChangeFlag("SHOOTABLE", 1)
+		TNT1 A 0 A_JumpIfCloser(300, "Waits")
+		Goto FollowPLayer
+	
+	Waits3:
+		TNT1 A 0
+		TNT1 A 0 A_JumpIfInTargetInventory("Clip2", 40, 3)
+		Goto GiveAmmo
+		TNT1 AAA 0
+		TNT1 A 0 A_SetAngle(random(90, -90) + angle)
+		MARN D 8 A_Stop
+		TNT1 A 0 A_PlaySound("MRNWC", 2)
+		MARN D 8 A_Stop
+		TNT1 A 0 A_CheckSight("FollowPlayer")
+		TNT1 A 0 A_ChangeFLag("FRIENDLY", 1)
+		TNT1 A 0 A_ClearTarget
+		
+		TNT1 A 0 A_ChangeFlag("SHOOTABLE", 1)
+		MARN D 0 A_Look
+		TNT1 A 0 A_ChangeFLag("FRIENDLY", 0)
+		TNT1 A 0 A_ChangeFlag("SHOOTABLE", 0)
+		MARN D 1 A_LookEx(0, 0, 0, 0, 0, "FollowPlayer")
+		TNT1 A 0 A_CheckSIght("FollowPlayer")
+		TNT1 A 0 A_ChangeFlag("SHOOTABLE", 1)
+		TNT1 A 0 A_JumpIfCloser(300, "Waits")
+		Goto FollowPLayer
+	
+	GiveAmmo:
+		TNT1 A 0
+		MR7S A 10 A_FaceTarget
+		TNT1 A 0 A_PlaySound("MRNGI1")
+		MR8S CD 15
+		TNT1 A 0 A_GiveToTarget("Clip2", 50)
+		//TNT1 A 0 A_SpawnItemEx("Stimpack", 40, 0)
+		Goto Waits
+	
+	Missile:
+        //PLAY E 1
+		TNT1 A 0 A_ChangeFlag("NODROPOFF", 1)
+		TNT1 A 0 A_SpawnItem("KillMeSmall")
+		TNT1 A 0 A_JumpIfInTargetInventory("TargetIsACyberdemon", 1, "CheckRetreat")
+		TNT1 A 0 A_JumpIfInTargetInventory("TargetIsAMastermind", 1, "CheckRetreat")
+		TNT1 A 0 A_JumpIfInTargetInventory("TargetIsABaronOfHell", 1, "CheckRetreat")
+		TNT1 A 0 A_JumpIfInTargetInventory("TargetIsAMancubus", 1, "CheckRetreat")
+		TNT1 A 0 A_JumpIfInTargetInventory("TargetIsAMarine", 1, "FollowPLayer")//
+		TNT1 A 0 A_JumpIfInTargetInventory("IsPlayer", 1, "CheckRangeToWait")
+		TNT1 A 0 A_ChangeFlag("SHOOTABLE", 1)
+		//TNT1 A 0 A_ChangeFlag("SOLID", 1)
+		TNT1 A 0 A_JumpIfCloser(60, "MeleeAttack")
+		TNT1 A 0 A_JumpIfCloser(300, "Retreat")
+		TNT1 A 0 A_PlaySound("MRNAT", 2)
+		
+		TNT1 A 0 A_Jump(128, "MissileLeft", "MissileRight")
+		
+		PLAY E 6 A_FaceTarget
+        TNT1 A 0 A_CustomMissile("MarineMuzzle1", 34)
+        TNT1 A 0 A_PlaySound("weapons/rifle")
+		PLAY F 3 BRIGHT 
+		TNT1 A 0 A_CustomMissile("MarineTracer", 40, 0, 0, 0)
+		TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 30,0)
+	
+	PLAY E 3 A_FaceTarget
+        TNT1 A 0 A_CustomMissile("MarineMuzzle1", 34)
+        TNT1 A 0 A_PlaySound("weapons/rifle")
+		PLAY F 3 BRIGHT
+		TNT1 A 0 A_CustomMissile("MarineTracer", 40, 0, 0, 0)
+		TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 30,0)
+	
+	PLAY E 3 A_FaceTarget
+        TNT1 A 0 A_CustomMissile("MarineMuzzle1", 34)
+        TNT1 A 0 A_PlaySound("weapons/rifle")
+		PLAY F 3 BRIGHT
+		TNT1 A 0 A_CustomMissile("MarineTracer", 40, 0, 0, 0)
+		TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 30,0)
+		Goto See
+		
+	MissileLeft:
+        TNT1 A 0
+	
+	MARN A 3 A_FaceTarget
+		TNT1 A 0 ThrustThing(angle*256/360+192, 3, 0, 0)
+        TNT1 A 0 A_CustomMissile("MarineMuzzle1", 34)
+        TNT1 A 0 A_PlaySound("weapons/rifle")
+		MARN B 3 BRIGHT 
+		TNT1 A 0 A_CustomMissile("MarineTracer", 42, 0, 0, 0)
+		TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 30,0)
+	
+	TNT1 A 0 ThrustThing(angle*256/360+192, 3, 0, 0)
+		MARN C 3 A_FaceTarget
+        TNT1 A 0 A_CustomMissile("MarineMuzzle1", 34)
+        TNT1 A 0 A_PlaySound("weapons/rifle")
+		MARN B 3 BRIGHT
+		TNT1 A 0 A_CustomMissile("MarineTracer", 42, 0, 0, 0)
+		TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 30,0)
+	
+	MARN A 3 A_FaceTarget
+		TNT1 A 0 ThrustThing(angle*256/360+192, 3, 0, 0)
+        TNT1 A 0 A_CustomMissile("MarineMuzzle1", 34)
+        TNT1 A 0 A_PlaySound("weapons/rifle")
+		MARN B 3 BRIGHT 
+		TNT1 A 0 A_CustomMissile("MarineTracer", 42, 0, 0, 0)
+		TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 30,0)
+	
+	MARN C 3 A_FaceTarget
+		TNT1 A 0 ThrustThing(angle*256/360+192, 3, 0, 0)
+        TNT1 A 0 A_CustomMissile("MarineMuzzle1", 34)
+        TNT1 A 0 A_PlaySound("weapons/rifle")
+		MARN B 3 BRIGHT
+		TNT1 A 0 A_CustomMissile("MarineTracer", 42, 0, 0, 0)
+		TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 30,0)
+		Goto See
+	
+	MissileRight:
+        TNT1 A 0
+	
+	MARN A 3 A_FaceTarget
+		TNT1 A 0 ThrustThing(angle*256/360+64, 3, 0, 0)
+        TNT1 A 0 A_CustomMissile("MarineMuzzle1", 34)
+        TNT1 A 0 A_PlaySound("weapons/rifle")
+		MARN B 3 BRIGHT 
+		TNT1 A 0 A_CustomMissile("MarineTracer", 42, 0, 0, 0)
+		TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 30,0)
+	
+	TNT1 A 0 ThrustThing(angle*256/360+64, 3, 0, 0)
+		MARN C 3 A_FaceTarget
+        TNT1 A 0 A_CustomMissile("MarineMuzzle1", 34)
+        TNT1 A 0 A_PlaySound("weapons/rifle")
+		MARN B 3 BRIGHT
+		TNT1 A 0 A_CustomMissile("MarineTracer", 42, 0, 0, 0)
+		TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 30,0)
+		
+		MARN A 3 A_FaceTarget
+		TNT1 A 0 ThrustThing(angle*256/360+64, 3, 0, 0)
+        TNT1 A 0 A_CustomMissile("MarineMuzzle1", 34)
+        TNT1 A 0 A_PlaySound("weapons/rifle")
+		MARN B 3 BRIGHT 
+		TNT1 A 0 A_CustomMissile("MarineTracer", 42, 0, 0, 0)
+		TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 30,0)
+	
+	MARN C 3 A_FaceTarget
+		TNT1 A 0 ThrustThing(angle*256/360+64, 3, 0, 0)
+        TNT1 A 0 A_CustomMissile("MarineMuzzle1", 34)
+        TNT1 A 0 A_PlaySound("weapons/rifle")
+		MARN B 3 BRIGHT
+		TNT1 A 0 A_CustomMissile("MarineTracer", 42, 0, 0, 0)
+		TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 30,0)
+		TNT1 A 0 A_ChangeFlag("SHOOTABLE", 1)
+        Goto See	
+		
+	CheckRetreat:
+		TNT1 A 0
+		TNT1 A 0 A_JumpIfCloser(500, "Retreat")
+		TNT1 A 0 A_Jump(256, "MissileRight", "MissileLeft")
+		Goto MissileRight
+		
+	Retreat:
+        TNT1 A 0
+		MARN A 3 A_FaceTarget
+		TNT1 A 0 A_Recoil(5)
+        TNT1 A 0 A_CustomMissile("MarineMuzzle1", 34)
+        TNT1 A 0 A_PlaySound("weapons/rifle")
+		MARN B 3 BRIGHT 
+		TNT1 A 0 A_CustomMissile("MarineTracer", 42, 0, 0, 0)
+		TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 30,0)
+
+        TNT1 A 0 A_Recoil(5)
+		MARN C 3 A_FaceTarget
+        TNT1 A 0 A_CustomMissile("MarineMuzzle1", 34)
+        TNT1 A 0 A_PlaySound("weapons/rifle")
+		MARN B 3 BRIGHT
+		TNT1 A 0 A_CustomMissile("MarineTracer", 42, 0, 0, 0)
+		TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 30,0)
+		
+		MARN A 3 A_FaceTarget
+		TNT1 A 0 A_Recoil(5)
+        TNT1 A 0 A_CustomMissile("MarineMuzzle1", 34)
+        TNT1 A 0 A_PlaySound("weapons/rifle")
+		MARN B 3 BRIGHT 
+		TNT1 A 0 A_CustomMissile("MarineTracer", 42, 0, 0, 0)
+		TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 30,0)
+		
+		MARN C 3 A_FaceTarget
+		TNT1 A 0 A_Recoil(5)
+        TNT1 A 0 A_CustomMissile("MarineMuzzle1", 34)
+        TNT1 A 0 A_PlaySound("weapons/rifle")
+		MARN B 3 BRIGHT
+		TNT1 A 0 A_CustomMissile("MarineTracer", 42, 0, 0, 0)
+		TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 30,0)
+		TNT1 A 0 A_Jump(128, "MissileRight", "MissileLeft")
+		Goto See	
+	
+	MeleeAttack:
+		TNT1 A 0
+		TNT1 A 0 A_JumpIfInTargetInventory("TargetIsAMarine", 1, "FollowPLayer")//
+		TNT1 A 0 A_Jump(32, "AttackKick")
+		PLAM A 4 A_FaceTarget
+		TNT1 A 0 A_Recoil(-4)
+		PLAM A 1 A_FaceTarget
+		PLAM B 4 A_CustomMissile("MarinePunch",40,0,0,0)
+		PLAM B 2
+		TNT1 A 0 A_JumpIfInventory("ZombiemanFatality3", 1, "FatalityZombieman")
+		TNT1 A 0 A_JumpIfInventory("ImpFatality3", 1, "FatalityImp")
+		TNT1 A 0 A_JumpIfInventory("SergeantFatality", 1, "FatalitySergeant")
+		TNT1 A 0 A_JumpIfInventory("RevenantFatality", 1, "FatalityRevenant")
+		Goto See
+	
+	AttackKick:
+		PLAY A 1 A_FaceTarget
+		TNT1 A 0 ThrustThingZ(0,40,0,1)
+		TNT1 A 0 A_Recoil(-8)
+		MARJ A 6 A_FaceTarget
+		AKIK A 1 A_CustomMissile("AirKickAttack",40,0,0,0)
+		TNT1 A 0 A_Stop
+		AKIK A 6
+		TNT1 A 0 A_JumpIfInventory("ZombiemanFatality3", 1, "FatalityZombieman")
+		TNT1 A 0 A_JumpIfInventory("ImpFatality3", 1, "FatalityImp")
+		TNT1 A 0 A_JumpIfInventory("SergeantFatality", 1, "FatalitySergeant")
+		TNT1 A 0 A_JumpIfInventory("RevenantFatality", 1, "FatalityRevenant")
+		Goto See
+	
+	Pain.Kick:
+		PLAY A 2 A_FaceTarget
+		TNT1 A 0 A_Recoil(5)
+        Goto FollowPlayer
+	
+	Pain:
+	    PLAY G 3
+		TNT1 A 0 A_ChangeFlag("NODROPOFF", 0)
+		PLAY G 3 A_Pain
+		Goto FollowPlayer
+	
+	Death:
+	Death.Bullet:
+		TNT1 A 0 A_ChangeFlag("USESPECIAL", 0)
+		TNT1 A 0 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_ChangeFlag("FRIENDLY", 0)
+		PLAY H 10 A_PlayerScream
+		
+		PLAY I 10 A_NoBlocking
+		PLAY J 10 
+		TNT1 A 0 A_SpawnItemEx("RemoveMarine",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+		PLAY KLM 10
+		TNT1 A 0 A_SpawnItem ("MediumBloodSpot")
+		PLAY N -1
+		Stop
+
+    Death.Eat:
+		TNT1 A 0 A_ChangeFlag("FRIENDLY", 0)
+		TNT1 A 0 A_ChangeFlag("USESPECIAL", 0)
+        TNT1 A 0 A_GiveToTarget("EatMe",1)
+		TNT1 A 0 A_CustomMissile ("XDeath1", 1, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("XDeath4", 1, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_SpawnItemEx("RemoveMarine",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+        XPL1 A 10 A_XScream
+        XPL1 B 20 A_NoBlocking
+        XPL1 CDE 10 
+		TNT1 A 0 A_SpawnItem ("MediumBloodSpot")
+        XPL1 E -1
+        Stop
+
+    Death.Cut:
+	Death.Saw:
+		TNT1 A 0
+		TNT1 A 0 A_ChangeFlag("USESPECIAL", 0)
+		TNT1 A 0 A_ChangeFlag("FRIENDLY", 0)
+		TNT1 A 0 A_CustomMissile ("XDeath1", 1, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("XDeath2", 1, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("XDeath3", 1, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("XDeath4", 1, 0, random (0, 360), 2, random (0, 160))
+        TNT1 A 0 A_CustomMissile ("RipGuts", 50, 0, random (0, 360), 2, random (0, 160))
+        TNT1 A 0 A_CustomMissile ("XDeathHalfMarine", 50, 0, random (0, 360), 2, random (0, 160))
+        TNT1 AA 0 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        XPL2 A 10 A_XScream
+        TNT1 AA 0 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        XPL2 B 20 A_NoBlocking
+		TNT1 A 0 A_SpawnItemEx("RemoveMarine",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+        TNT1 AA 0 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        XPL2 C 10 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        TNT1 AA 0 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        XPL2 DE 10 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_SpawnItem ("MediumBloodSpot")
+        XPL2 E -1
+        Stop
+
+    Death.Slime:
+		TNT1 A 0
+		TNT1 A 0 A_ChangeFlag("USESPECIAL", 0)
+		TNT1 A 0 A_ChangeFlag("FRIENDLY", 0)
+        TNT1 A 0 A_PlaySound("BIGSCREA")
+		TNT1 A 0 A_SpawnItemEx("RemoveMarine",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+        PMET AABBCCDDEEFFGGHHIIIII 10 A_CustomMissile ("PlasmaSmoke", 25, 0, random (0, 180), 2, random (0, 180))
+        PMET IIIIIIIIIIJJJJJJJJJJJJJJJJJJJJJJKKKKKKKKKKKKKKKKKKKKKKKKKKLLLLLLLLLLLLLLL 3 A_CustomMissile ("PlasmaSmoke", 25, 0, random (0, 180), 2, random (0, 180))
+        TNT1 A 0 A_NoBlocking
+        TNT1 A -1
+        Stop
+
+    Death.Minigun:
+		TNT1 A 0
+		TNT1 A 0 A_ChangeFlag("USESPECIAL", 0)
+		TNT1 A 0 A_ChangeFlag("FRIENDLY", 0)
+        TNT1 A 0 A_Jump (128, 3)
+        Goto Death
+        TNT1 AAA 0
+		TNT1 A 0 A_CustomMissile ("XDeath1", 1, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("XDeath2", 1, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("XDeath3", 1, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("XDeath4", 1, 0, random (0, 360), 2, random (0, 160))
+        TNT1 A 0 A_CustomMissile ("RipGuts", 50, 0, random (0, 360), 2, random (0, 160))
+        TNT1 A 0 A_CustomMissile ("XDeathHalfMarine", 50, 0, random (0, 360), 2, random (0, 160))
+        TNT1 AA 0 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        XPL2 A 10 A_XScream
+		TNT1 A 0 A_SpawnItemEx("RemoveMarine",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+        TNT1 AA 0 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        XPL2 B 20 A_NoBlocking
+        TNT1 AA 0 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        XPL2 C 10 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        TNT1 AA 0 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        XPL2 DE 10 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_SpawnItem ("MediumBloodSpot")
+        XPL2 E -1
+        Stop
+
+    Death.Rip:
+		TNT1 A 0
+		TNT1 A 0 A_ChangeFlag("FRIENDLY", 0)
+		TNT1 A 0 A_ChangeFlag("USESPECIAL", 0)
+        TNT1 AAAAAAAAAAA 0 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        XPL3 A 10 A_XScream
+        TNT1 AAAAA 0 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        XPL3 B 20 A_NoBlocking
+		TNT1 A 0 A_SpawnItemEx("RemoveMarine",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+        TNT1 A 0 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        XPL3 C 10 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        TNT1 A 0 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        XPL3 D 10 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        TNT1 A 0 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        XPL3 E 10 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        TNT1 A 0 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        XPL3 F 10 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        TNT1 A 0 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        XPL3 F 10 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_SpawnItem ("MediumBloodSpot")
+        XPL3 F -1
+        Stop
+	Death.Massacre:
+	Death.Explosives:
+	XDeath:
+		TNT1 A 0 ThrustThingZ(0,60,0,1)
+		TNT1 A 0 A_ChangeFlag("USESPECIAL", 0)
+		TNT1 A 0 A_ChangeFlag("FRIENDLY", 0)
+        TNT1 A 0 A_CustomMissile ("MarineXDeath", 0, 0, random (0, 360), 2, random (0, 160))
+		PPOD A 0 A_SpawnItemEx("BasicMarineGib1", 0, 0, 0, 0, 0, 0, 0, SXF_TRANSFERTRANSLATION)
+		PPOD A 0 A_SpawnItemEx("BasicMarineGib2", 0, 0, 0, 0, 0, 0, 0, SXF_TRANSFERTRANSLATION)
+		PPOD A 0 A_SpawnItemEx("BasicMarineGib3", 0, 0, 0, 0, 0, 0, 0, SXF_TRANSFERTRANSLATION)
+		PPOD A 0 A_SpawnItemEx("BasicMarineGib4", 0, 0, 0, 0, 0, 0, 0, SXF_TRANSFERTRANSLATION)
+        MHEA A 7 A_XScream
+        MHEA B 7 A_NoBlocking
+		TNT1 A 0 A_SpawnItemEx("RemoveMarine",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+        MHEA CD 7
+        MHEA E -1
+		Stop
+		
+	 Crush:
+	 Death.Stomp:
+		TNT1 A 0
+		TNT1 A 0 A_ChangeFlag("USESPECIAL", 0)
+		TNT1 A 0 A_ChangeFlag("FRIENDLY", 0)
+	    TNT1 AAAAAAAAAAAAAAAAAAAAAAAAA 0 A_CustomMissile ("Brutal_FlyingBloodTrail8", 0, 0, random (0, 360), 2, random (0, 360))
+		TNT1 AAAAAA 0 bright A_CustomMissile ("SuperGoreSpawner", 5, 0, random (0, 360), 2, random (30, 180))
+		TNT1 AAAAAA 0 bright A_CustomMissile ("XDeath1", 5, 0, random (0, 360), 2, random (30, 180))
+		TNT1 AA 0 bright A_CustomMissile ("XDeath2", 55, 0, random (0, 360), 2, random (30, 180))
+		TNT1 AA 0 bright A_CustomMissile ("XDeath3", 55, 0, random (0, 360), 2, random (30, 180))
+		TNT1 A 0 A_SpawnItem ("GrowingBloodPool")
+		TNT1 A 0 A_SpawnItem ("CrushedRemains")
+		TNT1 A 0 A_SpawnItemEx("RemoveMarine",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+		TNT1 A 1
+		TNT1 A 1 A_XScream
+		TNT1 A 1 A_NoBlocking
+		Stop	
+
+	Death.Blast:
+	Death.SuperPunch:
+	Death.SSG:
+		TNT1 A 0
+		TNT1 A 0 A_ChangeFlag("USESPECIAL", 0)
+		TNT1 A 0 A_ChangeFlag("FRIENDLY", 0)
+	    PLAY O 2 A_FaceTarget
+        TNT1 AAAA 0 A_CustomMissile ("XDeath1", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile ("XDeath2", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile ("XDeath3", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile ("Brutal_FlyingBlood", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile ("Brutal_FlyingBloodFaster", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile ("Brutal_FlyingBloodMuchFaster", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile ("SuperWallRedBlood", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile ("SuperWallRedBlood", 46, 0, random (170, 190), 2, random (0, 40))
+		TNT1 A 0 A_CustomMissile ("XDeathArm1", 32, 0, random (170, 190), 2, random (0, 40))
+        TNT1 A 0 A_XScream
+		TNT1 A 0 A_NoBlocking
+		TNT1 A 0 A_SpawnItemEx("RemoveMarine",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+        PLAY OPQRSTU 8
+		TNT1 A 0 A_SpawnItem ("MediumBloodSpot")
+        PLAY U -1
+        Stop
+
+    Death.Rape:
+		TNT1 A 0
+		TNT1 A 0 A_ChangeFlag("USESPECIAL", 0)
+		TNT1 A 0 A_ChangeFlag("FRIENDLY", 0)
+		TNT1 AAAAAAAAAAAAAA 0 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+		XPL4 A 20 A_XScream
+		 TNT1 A 0 A_CustomMissile ("XDeath1", 1, 0, random (0, 360), 2, random (0, 160))
+		 TNT1 A 0 A_CustomMissile ("XDeath2", 1, 0, random (0, 360), 2, random (0, 160))
+		 TNT1 A 0 A_CustomMissile ("XDeath3", 1, 0, random (0, 360), 2, random (0, 160))
+		 TNT1 A 0 A_CustomMissile ("XDeath4", 1, 0, random (0, 360), 2, random (0, 160))
+        TNT1 AAAA 0 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        XPL4 B 20 A_NoBlocking
+		TNT1 A 0 A_SpawnItemEx("RemoveMarine",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+        TNT1 AAA 0 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        XPL4 C 20
+        TNT1 AAA 0 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        XPL4 D 20
+        TNT1 AAAA 0 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        XPL4 E 20
+        TNT1 AAA 0 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+        XPL4 F 20
+        TNT1 AAAA 0 A_CustomMissile ("MuchBlood", 50, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_SpawnItem ("MediumBloodSpot")
+        XPL4 F -1
+        Stop
+
+    Death.plasma:
+        TNT1 A 0
+		TNT1 A 0 A_ChangeFlag("USESPECIAL", 0)
+		TNT1 A 0 A_ChangeFlag("FRIENDLY", 0)
+        TNT1 A 0 A_XScream
+        TNT1 A 0 A_NoBlocking
+        TNT1 AAA 0 A_CustomMissile ("Brutal_FlyingBlood", 50, 0, random (0, 360), 2, random (0, 160))
+	    TNT1 A 0 A_CustomMissile ("XDeathBurnedArm", 32, 0, random (0, 360), 2, random (0, 160))
+	    TNT1 A 0 A_CustomMissile ("XDeathBurnedLeg", 32, 0, random (0, 360), 2, random (0, 160))
+	    TNT1 A 0 A_CustomMissile ("XDeathBurnedSkull", 32, 0, random (0, 360), 2, random (0, 160))
+	    TNT1 A 0 A_CustomMissile ("XDeathBurnedMeat", 32, 0, random (0, 360), 2, random (0, 160))
+	    TNT1 A 0 A_CustomMissile ("XDeathBurnedMeat2", 32, 0, random (0, 360), 2, random (0, 160))
+	    TNT1 A 0 A_CustomMissile ("XDeathBurnedMeat3", 32, 0, random (0, 360), 2, random (0, 160))
+		EXPL AAAAAA 0 A_CustomMissile ("ExplosionSmoke", 32, 0, random (0, 360), 2, random (0, 360))
+        TNT1 A 1
+		TNT1 A 0 A_SpawnItemEx("RemoveMarine",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+        TNT1 A -1
+        Stop
+	
+	Death.GreenFire:
+        TNT1 A 0
+		TNT1 A 0 A_ChangeFlag("USESPECIAL", 0)
+		TNT1 A 0 A_ChangeFlag("FRIENDLY", 0)
+        TNT1 A 0 A_XScream
+        TNT1 A 0 A_NoBlocking
+        TNT1 AAAA 0 A_CustomMissile ("Brutal_Blood", 30, 0, random (0, 360), 2, random (0, 160))
+		
+	    TNT1 A 0 A_CustomMissile ("XDeathBurnedArm", 32, 0, random (0, 360), 2, random (0, 160))
+	    TNT1 A 0 A_CustomMissile ("XDeathBurnedLeg", 32, 0, random (0, 360), 2, random (0, 160))
+	    TNT1 A 0 A_CustomMissile ("XDeathBurnedSkull", 32, 0, random (0, 360), 2, random (0, 160))
+	    TNT1 A 0 A_CustomMissile ("XDeathBurnedMeat", 32, 0, random (0, 360), 2, random (0, 160))
+	    TNT1 A 0 A_CustomMissile ("XDeathBurnedMeat2", 32, 0, random (0, 360), 2, random (0, 160))
+	    TNT1 A 0 A_CustomMissile ("XDeathBurnedMeat3", 32, 0, random (0, 360), 2, random (0, 160))
+		
+		EXPL AAAAAAAAAAAAAAAAAAAAAAAA 0 A_CustomMissile ("GreenFlameTrails", 50, 0, random (0, 360), 2, random (0, 360))
+		XBRN AAAA 2 BRIGHT A_SpawnItem("GreenFlare",0,43)
+		TNT1 A 0 A_SpawnItemEx("RemoveMarine",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+        Stop
+
+    Death.burn:
+	TNT1 A 0
+	TNT1 A 0 A_ChangeFlag("USESPECIAL", 0)
+	TNT1 A 0 A_ChangeFlag("FRIENDLY", 0)
+	 PBUR A 1
+      PBUR A 1 A_Scream
+      PBUR A 1 A_NoBlocking
+	  TNT1 A 0 A_SpawnItemEx("RemoveMarine",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+       PBUR AAAABBBBCCCC 2 A_CustomMissile ("SmallFlameTrails", 32, 0, random (0, 180), 2, random (0, 180))
+	    PBUR DDDDEEEE 2 A_CustomMissile ("SmallFlameTrails", 16, 0, random (0, 180), 2, random (0, 180))
+        PBUR EEEEE 4 A_CustomMissile ("SmallFlameTrails", 8, 0, random (0, 180), 2, random (0, 180))
+		PBUR EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE 6 A_CustomMissile ("PlasmaSmoke", 8, 0, random (0, 180), 2, random (0, 180))
+        PBUR E -1
+        Stop
+
+    Death.Fire:
+	Death.Flames:
+	Death.Burn:
+	TNT1 A 0
+		TNT1 A 0 A_ChangeFlag("USESPECIAL", 0)
+		TNT1 A 0 A_ChangeFlag("FRIENDLY", 0)
+        TNT1 A 0 A_PlaySound("BIGSCREA")
+      BURN W 6 A_Scream
+      BURN X 6 A_NoBlocking
+	  TNT1 A 0 A_SpawnItemEx("RemoveMarine",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+       BUR2 ABCD 6 BRIGHT A_CustomMissile ("PlasmaSmoke", 8, 0, random (0, 180), 2, random (0, 180))
+       BURN FGHIJKL 6 BRIGHT A_CustomMissile ("PlasmaSmoke", 8, 0, random (0, 180), 2, random (0, 180))
+       BURN MNOPQRSTUV 6 BRIGHT A_CustomMissile ("PlasmaSmoke", 8, 0, random (0, 180), 2, random (0, 180))
+        BURN VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV 6 A_CustomMissile ("PlasmaSmoke", 8, 0, random (0, 180), 2, random (0, 180))
+        BURN V -1
+      Stop
+	
+	Death.ExplosiveImpact:
+		TNT1 A 0
+		TNT1 A 0 A_ChangeFlag("USESPECIAL", 0)
+		TNT1 A 0 A_ChangeFlag("FRIENDLY", 0)
+		NULL A 0 ThrustThingZ(0,30,0,1)
+		NULL AAAA 0 A_CustomMissile ("Brains1", 50, 0, random (0, 360), 2, random (0, 160))
+		NULL A 0 A_CustomMissile ("Brains2", 50, 0, random (0, 360), 2, random (0, 160))
+		NULL A 0 A_CustomMissile ("Brains3", 50, 0, random (0, 360), 2, random (0, 160))
+		NULL A 0 A_CustomMissile ("Brains4", 50, 0, random (0, 360), 2, random (0, 160))
+		NULL A 0 A_CustomMissile ("Brains5", 50, 0, random (0, 360), 2, random (0, 160))
+		NULL AAAA 0 A_CustomMissile ("SmallBrainPiece", random (45, 55), random (5, -5), random (170, 190), 2, random (0, 40))
+		NULL AAAA 0 A_CustomMissile ("SmallBrainPiece", 50, 0, random (0, 360), 2, random (0, 160))
+		NULL AA 0 A_CustomMissile ("SuperWallRedBlood", 46, 0, random (170, 190), 2, random (0, 40))
+        NULL AAAAAAAAAAA 0 A_CustomMissile ("BrainBlood", 50, 0, random (0, 360), 2, random (0, 160))
+	    NULL A 0 A_CustomMissile ("XDeathArm1", 35, 0, random (0, 360), 2, random (0, 160))
+	    NULL A 0 A_CustomMissile ("XDeath3", 40, 0, random (0, 360), 2, random (0, 160))
+	    PPOD A 0 A_SpawnItemEx("BasicMarineGib1", 0, 0, 0, 0, 0, 0, 0, SXF_TRANSFERTRANSLATION)
+        NULL AAAA 0 A_CustomMissile ("XDeath1", 40, 0, random (0, 360), 2, random (0, 160))
+		NULL A 0 A_XScream
+        XPL6 A 5
+		NULL A 0 A_NoBlocking
+        XPL6 BCDE 5
+		TNT1 A 0 A_SpawnItemEx("RemoveMarine",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+        XPL6 F -1
+        Stop
+
+    Crush:
+        TNT1 A 0 A_PlaySound("misc/xdeath4")
+		TNT1 A 0 A_ChangeFlag("USESPECIAL", 0)
+		
+        CRS1 A 5
+        CRS1 A -1
+        Stop
+
+    Death.HKFT:
+	Death.BHFT:
+	Death.RVFT:
+		TNT1 A 1 A_Scream
+		TNT1 A 0 A_ChangeFlag("USESPECIAL", 0)
+		TNT1 A 1 A_NoBlocking
+        TNT1 A 0 A_GiveToTarget("Curbstomp_Marine",1)
+		TNT1 A 0
+		TNT1 A 0 A_ChangeFlag("FRIENDLY", 0)
+		TNT1 A 5
+		TNT1 A 0 A_SpawnItemEx("RemoveMarine",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+		TNT1 A -1
+        Stop
+
+    Death.FatalityMarine:
+		TNT1 A 1 A_PlayerScream
+		TNT1 A 0 A_GiveToTarget("GoFatality", 1)
+		TNT1 A 1 A_NoBlocking
+		TNT1 A 0 A_SpawnItemEx("RemoveMarine",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+        TNT1 A 0 A_GiveToTarget("Fatality_Marine",1)
+		TNT1 A -1
+        Stop
+		
+	FatalityZombieman:
+	TNT1 A 0
+	TNT1 A 0 A_Jump(255, "FatalityZombieman1", "FatalityZombieman2", "FatalityZombieman3")
+	Goto FatalityZombieman1
+	
+	FatalityZombieman1:
+	    TNT1 A 0
+		TNT1 A 0 A_ChangeFlag (shootable, 0)
+		TNT1 A 0 A_ChangeFlag (Invulnerable, 1)
+        //////////////////////////////////////////////////////
+        FPZ3 A 10
+		FPZ3 ABCDE 4
+        XXXX A 0 A_CustomMissile ("CameraShake", 1, 0, random (0, 360), 2, random (0, 160))
+        TNT1 A 0 A_PlaySound("grunt/pain", 1)
+		FPZ3 FGGGG 4
+        
+		FPZ3 HHIIIIIIHJJ 2
+        XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
+		 TNT1 A 0 A_PlaySound("grunt/pain", 1)
+		 TNT1 A 0 A_PlaySound("player/cyborg/fist", 4)
+		TNT1 AA 0 A_CustomMissile ("XDeath1", 60, 0, random (0, 360), 2, random (0, 160))
+        TNT1 AAAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
+		
+		FPZ3 KKLLLLKJJ 2
+        XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
+		 TNT1 A 0 A_PlaySound("grunt/pain", 1)
+		 TNT1 A 0 A_PlaySound("player/cyborg/fist", 4)
+		TNT1 AA 0 A_CustomMissile ("XDeath1", 60, 0, random (0, 360), 2, random (0, 160))
+        TNT1 AAAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
+        
+		FPZ3 MMNNNNMOO 2
+        XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
+		 TNT1 A 0 A_PlaySound("grunt/pain", 1)
+		 TNT1 A 0 A_PlaySound("player/cyborg/fist", 4)
+		TNT1 AA 0 A_CustomMissile ("XDeath1", 60, 0, random (0, 360), 2, random (0, 160))
+        TNT1 AAAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
+		FPZ3 MMNNNNMOO 2
+        XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
+		 TNT1 A 0 A_PlaySound("player/cyborg/fist", 4)
+		TNT1 AA 0 A_CustomMissile ("XDeath1", 30, 0, random (0, 360), 2, random (0, 160))
+        TNT1 AAAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AAAA 0 A_CustomMissile ("Brains1", 5, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("Brains2", 5, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("Brains3", 5, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("Brains4", 5, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("Brains5", 5, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("Brains5", 5, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AAAAAAAA 0 A_CustomMissile ("SmallBrainPiece", 5, 0, random (0, 360), 2, random (0, 160))
+	
+	FPZ3 PPQQQQPRR 2
+        XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
+		 TNT1 A 0 A_PlaySound("player/cyborg/fist", 4)
+		TNT1 A 0 A_CustomMissile ("XDeath1", 60, 0, random (0, 360), 2, random (0, 160))
+        TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
+		
+		FPZ3 PPQQQPRR 2
+        TNT1 A 0 ACS_Execute(580, 0, 0, 0, 0)
+        TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
+		XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
+		 TNT1 A 0 A_PlaySound("player/cyborg/fist", 4)
+		TNT1 A 0 A_CustomMissile ("XDeath1", 60, 0, random (0, 360), 2, random (0, 160))
+        TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
+		FPZ3 RP 5
+		
+		TNT1 A 0 A_PlaySound("PLATA1", 1)
+        //////////////////////////////////////////////////////
+		TNT1 A 0 A_TakeInventory("ZombieManFatality3",1)
+        TNT1 A 0 A_SpawnItem ("DeadZombieManFatality3")
+		TNT1 A 0 A_ChangeFlag (shootable, 1)
+		TNT1 A 0 A_ChangeFlag (Invulnerable, 0)
+        Goto FollowPlayer
+		
+		FatalityZombieman2:
+        TNT1 A 0
+		TNT1 A 0 A_ChangeFlag (shootable, 0)
+		TNT1 A 0 A_ChangeFlag (Invulnerable, 1)
+        //////////////////////////////////////////////////////
+        FPZ2 AB 5
+		XXXX A 0 A_CustomMissile ("CameraShake", 1, 0, random (0, 360), 2, random (0, 160))
+		 TNT1 AAAAAA 0 A_CustomMissile ("CeilBloodLauncher", 50, 0, random (0, 360), 2, random (50, 130))
+         TNT1 AAAA 0 A_CustomMissile ("XDeath1", 60, 0, random (0, 360), 2, random (0, 160))
+         TNT1 AA 0 A_CustomMissile ("XDeath2", 60, 0, random (0, 360), 2, random (0, 160))
+         TNT1 AA 0 A_CustomMissile ("XDeath3", 60, 0, random (0, 360), 2, random (0, 160))
+         TNT1 AAAAAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 60, 0, random (0, 360), 2, random (0, 160))
+        FPZ2 C 15
+		TNT1 A 0 A_PlaySound("imp/melee")
+        FPZ2 D 15
+		TNT1 AAAAA 0 A_CustomMissile ("Guts2", 32, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AAA 0 A_CustomMissile ("XDeath1", 60, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AAAAAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 60, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 ACS_Execute(580, 0, 0, 0, 0)
+		FPZ2 EF 5
+		TNT1 A 0 A_PlaySound("grunt/death")
+		FPZ2 G 10
+        //////////////////////////////////////////////////////
+        TNT1 A 0 A_TakeInventory("ZombieManFatality3",1)
+        TNT1 A 0 A_SpawnItem ("ZombieManDyingAfterFatality")
+		TNT1 A 0 A_ChangeFlag (shootable, 1)
+		TNT1 A 0 A_ChangeFlag (Invulnerable, 0)
+        Goto FollowPlayer
+	
+	FatalityZombieman3:
+        TNT1 A 0
+		TNT1 A 0 A_ChangeFlag (shootable, 0)
+		TNT1 A 0 A_ChangeFlag (Invulnerable, 1)
+        //////////////////////////////////////////////////////
+        FPZ4 AB 3
+		XXXX A 0 A_CustomMissile ("CameraShake", 1, 0, random (0, 360), 2, random (0, 160))
+        TNT1 A 0 A_PlaySound("grunt/pain", 1)
+		TNT1 A 0 A_PlaySound("player/cyborg/fist", 4)
+		FPZ4 CDEEE 3
+		FPZ4 FGH 3
+        
+		FPZ4 HHI 2
+        TNT1 A 0 ACS_Execute(580, 0, 0, 0, 0)
+        TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
+		 XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
+		 TNT1 A 0 A_PlaySound("grunt/pain", 1)
+		 TNT1 A 0 A_PlaySound("player/cyborg/fist", 4)
+		TNT1 A 0 A_CustomMissile ("XDeath1", 15, 0, random (0, 360), 2, random (0, 160))
+        TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("Teeth", 15, 0, random (0, 360), 2, random (0, 160))
+		FPZ4 JJJIH 2
+		
+		FPZ4 HHI 2
+        TNT1 A 0 ACS_Execute(580, 0, 0, 0, 0)
+        TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
+		 XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
+		 TNT1 A 0 A_PlaySound("grunt/pain", 1)
+		 TNT1 A 0 A_PlaySound("player/cyborg/fist", 4)
+		TNT1 A 0 A_CustomMissile ("XDeath1", 15, 0, random (0, 360), 2, random (0, 160))
+        TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("Teeth", 15, 0, random (0, 360), 2, random (0, 160))
+		FPZ4 JJJIH 2
+		
+		FPZ4 HHI 2
+        TNT1 A 0 ACS_Execute(580, 0, 0, 0, 0)
+        TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
+		 XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
+		 TNT1 A 0 A_PlaySound("grunt/pain", 1)
+		 TNT1 A 0 A_PlaySound("player/cyborg/fist", 4)
+		TNT1 A 0 A_CustomMissile ("XDeath1", 15, 0, random (0, 360), 2, random (0, 160))
+        TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("Teeth", 15, 0, random (0, 360), 2, random (0, 160))
+		FPZ4 OOOMN 2
+	
+	FPZ4 NNM 2
+        TNT1 A 0 ACS_Execute(580, 0, 0, 0, 0)
+        TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
+		 XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
+		 TNT1 A 0 A_PlaySound("grunt/pain", 1)
+		 TNT1 A 0 A_PlaySound("player/cyborg/fist", 4)
+		TNT1 A 0 A_CustomMissile ("XDeath1", 15, 0, random (0, 360), 2, random (0, 160))
+        TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("Teeth", 15, 0, random (0, 360), 2, random (0, 160))
+		FPZ4 OOOMN 2
+		
+		FPZ4 NNM 2
+        TNT1 A 0 ACS_Execute(580, 0, 0, 0, 0)
+        TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
+		 XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
+		 TNT1 A 0 A_PlaySound("grunt/pain", 1)
+		 TNT1 A 0 A_PlaySound("player/cyborg/fist", 4)
+		TNT1 A 0 A_CustomMissile ("XDeath1", 15, 0, random (0, 360), 2, random (0, 160))
+        TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("Teeth", 15, 0, random (0, 360), 2, random (0, 160))
+		FPZ4 OOOMN 2
+	
+	FPZ4 NNM 2
+        TNT1 A 0 ACS_Execute(580, 0, 0, 0, 0)
+        TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
+		 XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
+		 TNT1 A 0 A_PlaySound("grunt/pain", 1)
+		 TNT1 A 0 A_PlaySound("player/cyborg/fist", 4)
+		TNT1 A 0 A_CustomMissile ("XDeath1", 15, 0, random (0, 360), 2, random (0, 160))
+        TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
+		
+		TNT1 A 0 A_CustomMissile ("Teeth", 15, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 ACS_Execute(580, 0, 0, 0, 0)
+        TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
+		 XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
+		 TNT1 A 0 A_PlaySound("player/cyborg/fist", 4)
+		TNT1 A 0 A_CustomMissile ("XDeath1", 15, 0, random (0, 360), 2, random (0, 160))
+        TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("Teeth", 15, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AAAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AAAA 0 A_CustomMissile ("Brains1", 5, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("Brains2", 5, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("Brains3", 5, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("Brains4", 5, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("Brains5", 5, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("Brains5", 5, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AAAAAAAA 0 A_CustomMissile ("SmallBrainPiece", 5, 0, random (0, 360), 2, random (0, 160))
+		FPZ4 P 7
+		FPZ4 L 10
+        //////////////////////////////////////////////////////
+        TNT1 A 0 A_TakeInventory("ZombieManFatality3",1)
+        TNT1 A 0 A_SpawnItem ("DeadZombieManFatality3")
+		TNT1 A 0 A_ChangeFlag (shootable, 1)
+		TNT1 A 0 A_ChangeFlag (Invulnerable, 0)
+        Goto FollowPlayer
+	
+	FatalityImp:
+		TNT1 A 0 A_ChangeFlag (shootable, 0)
+		TNT1 A 0 A_ChangeFlag (Invulnerable, 1)
+		TNT1 A 0 A_Jump(128, "FatalityImp2")
+        //////////////////////////////////////////////////////
+        FTCI AB 4
+		XXXX A 0 A_CustomMissile ("CameraShake", 1, 0, random (0, 360), 2, random (0, 160))
+        TNT1 A 0 A_PlaySound("grunt/pain", 1)
+		TNT1 A 0 A_PlaySound("player/cyborg/fist", 4)
+		FTCI CDE 4
+		FTCI E 8
+        
+		FTCI FGG 5
+		FTCI H 2
+		 XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
+		 TNT1 A 0 A_PlaySound("grunt/pain", 1)
+		 TNT1 A 0 A_PlaySound("player/cyborg/fist", 4)
+		TNT1 A 0 A_CustomMissile ("XDeath1", 15, 0, random (0, 360), 2, random (0, 160))
+        TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("Teeth", 15, 0, random (0, 360), 2, random (0, 160))
+		FTCI I 10
+		FTCI H 5
+		FTCI G 8
+		
+		FTCI H 2
+		 XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
+		 TNT1 A 0 A_PlaySound("grunt/pain", 1)
+		 TNT1 A 0 A_PlaySound("player/cyborg/fist", 4)
+		TNT1 A 0 A_CustomMissile ("XDeath1", 15, 0, random (0, 360), 2, random (0, 160))
+        TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("Teeth", 15, 0, random (0, 360), 2, random (0, 160))
+		FTCI I 10
+		FTCI H 5
+		FTCI G 8
+		
+		FTCI H 2
+		 XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
+		 TNT1 A 0 A_PlaySound("grunt/pain", 1)
+		 TNT1 A 0 A_PlaySound("player/cyborg/fist", 4)
+		TNT1 A 0 A_CustomMissile ("XDeath1", 15, 0, random (0, 360), 2, random (0, 160))
+        TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("Teeth", 15, 0, random (0, 360), 2, random (0, 160))
+		FTCI I 10
+		FTCI H 5
+		FTCI G 8
+		
+		FTCI H 2
+		 XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
+		 TNT1 A 0 A_PlaySound("grunt/pain", 1)
+		 TNT1 A 0 A_PlaySound("player/cyborg/fist", 4)
+		TNT1 A 0 A_CustomMissile ("XDeath1", 15, 0, random (0, 360), 2, random (0, 160))
+        TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("Teeth", 15, 0, random (0, 360), 2, random (0, 160))
+		FTCI I 10
+		FTCI H 5
+		FTCI G 8
+		
+		FTCI H 2
+		
+		 XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
+		 TNT1 A 0 A_PlaySound("grunt/pain", 1)
+		 TNT1 A 0 A_PlaySound("player/cyborg/fist", 4)
+		TNT1 AAAAA 0 A_CustomMissile ("XDeath1", 15, 0, random (0, 360), 2, random (0, 160))
+        TNT1 AAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("Teeth", 15, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AAAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AAAA 0 A_CustomMissile ("Brains1", 5, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("Brains2", 5, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("Brains3", 5, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("Brains4", 5, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("Brains5", 5, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("Brains5", 5, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AAAAAAAA 0 A_CustomMissile ("SmallBrainPiece", 5, 0, random (0, 360), 2, random (0, 160))
+		FTCI L 10
+		FTCI J 20
+        //////////////////////////////////////////////////////
+        TNT1 A 0 A_TakeInventory("GoFatality", 1)
+		TNT1 A 0 A_ChangeFlag (shootable, 1)
+		TNT1 A 0 A_TakeInventory("ImpFatality3",1)
+		TNT1 A 0 A_GiveInventory("Stimpack",1)
+        TNT1 A 0 A_SpawnItem ("impfacesorapedomgthisiscruel")
+		TNT1 A 0 A_ChangeFlag (shootable, 1)
+		TNT1 A 0 A_ChangeFlag (Invulnerable, 0)
+        Goto FollowPlayer	
+	
+	FatalityImp2:
+        FTYI ABB 7
+        FTYI CDEFG 2
+        TNT1 A 0  A_PlaySound("imp/pain")
+        TNT1 A 0 A_SpawnItemEx("FootStep5", 0, 0, 40, 0, 0)
+          TNT1 A 0 A_PlaySound("CLAP")
+XXXX A 0 A_CustomMissile ("CameraShake", 1, 0, random (0, 360), 2, random (0, 160))
+        FTYI GGGGHHHHHHHHIJJJ 2
+        FTYI K 3
+XXXX A 0 A_CustomMissile ("CameraShake", 1, 0, random (0, 360), 2, random (0, 160))
+TNT1 A 0 ACS_Execute(580, 0, 0, 0, 0)
+TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
+TNT1 A 0 ACS_Execute(582, 0, 0, 0, 0)
+TNT1 A 0 ACS_Execute(583, 0, 0, 0, 0)
+        TNT1 A 0 A_SpawnItemEx("FootStep5", 0, 25, 30, 0, 0)
+        TNT1 AAA 0 A_CustomMissile ("Brains1", 11, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("Brains2", 11, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("Brains3", 11, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("Brains4", 11, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("Brains5", 11, 0, random (0, 360), 2, random (0, 160))
+         TNT1 AAAA 0 A_CustomMissile ("XDeath1", 15, 0, random (0, 360), 2, random (0, 160))
+         TNT1 AAAAAAAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 15, 0, random (0, 360), 2, random (0, 160))
+		 FTYI LLLL 1 A_SpawnItemEx("Brutal_Blood", 0, 25, 10, 0, 0)
+           FTYI LMNNN 4
+           FTYI NO 6
+		   TNT1 A 0 A_PlaySound("misc/xdeath3")
+		   FTYI NO 6
+		   TNT1 A 0 A_PlaySound("misc/xdeath3")
+		   FTYI NO 6
+		   TNT1 A 0 A_PlaySound("misc/xdeath3")
+		   FTYI N 8
+        //////////////////////////////////////////////////////
+        TNT1 A 0 A_TakeInventory("GoFatality", 1)
+		TNT1 A 0 A_TakeInventory("ImpFatality3",1)
+		TNT1 A 0 A_CustomMissile ("StompedImp", 1, 0, random (0, 360), 2, random (0, 160))
+        TNT1 A 0 A_ChangeFlag (shootable, 1)
+		TNT1 A 0 A_ChangeFlag (Invulnerable, 0)
+        Goto FollowPlayer	
+	
+	FatalitySergeant:
+        TNT1 A 0
+		TNT1 A 0 A_Jump(128, "FatalitySergeant2")
+		TNT1 A 0 A_ChangeFlag (shootable, 0)
+		TNT1 A 0 A_ChangeFlag (Invulnerable, 1)
+        //////////////////////////////////////////////////////
+        FTYS A 8 A_PlaySound("grunt/pain")
+        FTYS BC 8
+		TNT1 A 0 A_PlaySound("BURNZOM", 3)
+
+        TNT1 A 0 A_PlaySound("misc/xdeath")
+        FTYS DE 4
+		TNT1 A 0 A_PlaySound("misc/xdeath")
+		FTYS DE 4
+		TNT1 A 0 A_PlaySound("misc/xdeath")
+		FTYS DE 4
+		
+XXXX A 0 A_CustomMissile ("CameraShake", 1, 0, random (0, 360), 2, random (0, 160))
+TNT1 A 0 A_PlaySound("misc/xdeath", 3)
+TNT1 AAAA 0 A_CustomMissile ("XDeath1", 20, 0, random (0, 360), 2, random (0, 160))
+TNT1 AAAAAAAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 60, 0, random (0, 360), 2, random (0, 160))
+        FTYS FGHIPP 4 A_CustomMissile ("Blood", 1, 0, random (0, 360), 2, random (0, 160))
+
+        FTYS QR 8 
+        TNT1 A 0 A_SpawnItemEx("FootStep5", 0, 0, 40, 0, 0)
+        FTYS R 20
+        ///////////////////////////////////////////////////////
+        TNT1 A 0 A_TakeInventory("GoFatality", 1)
+		TNT1 A 0 A_TakeInventory("SergeantFatality",1)
+		 TNT1 A 0 A_CustomMissile ("BeheadedSergeantZombie", 1, 0, random (0, 360), 2, random (0, 160))
+        TNT1 A 0 A_ChangeFlag (shootable, 1)
+		TNT1 A 0 A_ChangeFlag (Invulnerable, 0)
+        Goto FollowPlayer
+	
+	FatalitySergeant2:  ///////
+        TNT1 A 0
+		TNT1 A 0 A_ChangeFlag (shootable, 0)
+		TNT1 A 0 A_ChangeFlag (Invulnerable, 1)
+        //////////////////////////////////////////////////////
+        FSP3 A 8
+		
+		FSP3 B 4 A_PlaySound("grunt/pain")
+		XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
+		FSP3 CDE 4
+		FSP3 E 6
+		
+		FSP3 FG 4
+TNT1 A 0 A_PlaySound("grunt/death")		
+XXXX A 0 A_CustomMissile ("ShakeYourAssMinor", 1, 0, random (0, 360), 2, random (0, 160))
+TNT1 AAAA 0 A_CustomMissile ("XDeath1", 20, 0, random (0, 360), 2, random (0, 160))
+//TNT1 AA 0 A_CustomMissile ("XDeath2", 20, 0, random (0, 360), 2, random (0, 160))
+//TNT1 AA 0 A_CustomMissile ("XDeath3", 20, 0, random (0, 360), 2, random (0, 160))
+TNT1 AAAA 0 A_CustomMissile ("PlayerFlyingBlood", 60, 0, random (0, 360), 2, random (0, 160))
+       FSP3 HIIIII 5
+	   
+	   TNT1 A 0 A_PlaySound("weapons/sg")	
+	   XXXX A 0 A_CustomMissile ("CameraShake", 1, 0, random (0, 360), 2, random (0, 160))
+TNT1 AAAAA 0 A_CustomMissile ("XDeath1", 70, 0, random (0, 360), 2, random (0, 160))
+TNT1 AAA 0 A_CustomMissile ("XDeath2", 70, 0, random (0, 360), 2, random (0, 160))
+TNT1 AAA 0 A_CustomMissile ("XDeath3", 70, 0, random (0, 360), 2, random (0, 160))
+TNT1 AAAAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 70, 0, random (0, 360), 2, random (0, 160))
+        TNT1 A 0 A_CustomMissile ("FlyingImpaledSergeant", 50, 0, random (0, 360), 2, random (70, 110))
+	
+	FSP3 L 3 BRIGHT
+		FSP3 K 3
+		FSP3 J 40
+		///////////////////////////////////////////////////////
+        TNT1 A 0 A_TakeInventory("GoFatality", 1)
+		TNT1 A 0 A_TakeInventory("SergeantFatality",1)
+		TNT1 A 0 A_ChangeFlag (shootable, 1)
+		TNT1 A 0 A_ChangeFlag (Invulnerable, 0)
+        Goto FollowPlayer
+	
+	FatalityRevenant:
+        
+		TNT1 A 0 A_ChangeFlag (shootable, 0)
+		TNT1 A 0 A_ChangeFlag (Invulnerable, 1)
+        //////////////////////////////////////////////////////
+        FREV ABABAB 3
+XXXX A 0 A_CustomMissile ("CameraShake", 1, 0, random (0, 360), 2, random (0, 160))
+		 TNT1 AAAAAA 0 A_CustomMissile ("CeilBloodLauncher", 40, 0, random (0, 360), 2, random (50, 130))
+         TNT1 AAAA 0 A_CustomMissile ("XDeath1", 10, 0, random (0, 360), 2, random (0, 160))
+         TNT1 AAAAAAAAAAAAAAAAAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 50, 0, random (0, 360), 2, random (0, 160))
+		 TNT1 A 0 ACS_Execute(580, 0, 0, 0, 0)
+TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
+TNT1 A 0 ACS_Execute(582, 0, 0, 0, 0)
+        FREV C 4 A_PlaySound("skeleton/pain")
+        FREV D 4
+        FREV EFGHIJJJKL 4
+        FREV M 5 A_PlaySound("skeleton/sight")
+        FREV M 10
+        FREV N 2
+        FREV O 2
+
+XXXX A 0 A_CustomMissile ("CameraShake", 1, 0, random (0, 360), 2, random (0, 160))
+		 TNT1 AA 0 A_CustomMissile ("XDeath1", 50, 0, random (0, 360), 2, random (0, 160))
+		 TNT1 AAA 0 A_CustomMissile ("XDeath2", 50, 0, random (0, 360), 2, random (0, 160))
+		 TNT1 AAA 0 A_CustomMissile ("XDeath3", 50, 0, random (0, 360), 2, random (0, 160))
+         TNT1 A 0 A_CustomMissile ("XDeathRevenantHead", 45, 0, random (0, 360), 2, random (50, 130))
+TNT1 A 0 ACS_Execute(580, 0, 0, 0, 0)
+TNT1 A 0 ACS_Execute(581, 0, 0, 0, 0)
+TNT1 A 0 ACS_Execute(582, 0, 0, 0, 0)
+TNT1 A 0 ACS_Execute(583, 0, 0, 0, 0)
+
+        FREV PQR 2
+        //////////////////////////////////////////////////////
+        TNT1 A 0 A_TakeInventory("GoFatality", 1)
+		TNT1 A 0 A_TakeInventory("RevenantFatality",1)
+		TNT1 A 0 A_SpawnItemEx("DyingRevenant", 0, 35, 35, 1, 1)
+        TNT1 A 0 SetPlayerProperty(0,0,0)
+        TNT1 A 0 A_ChangeFlag (shootable, 1)
+		TNT1 A 0 A_ChangeFlag (Invulnerable, 0)
+        Goto Spawn
+	
+	FatalityComando:
+			TNT1 A 0 A_ChangeFlag (shootable, 0)
+		TNT1 A 0 A_ChangeFlag (Invulnerable, 1)
+			//////////////////////////////////////////////////////
+			CFTA AAABCDE 2
+			  NULL A 0 A_PlaySound("grunt/pain")
+	NULL A 0 A_SpawnItemEx("FootStep5", 0, 0, 40, 0, 0)
+	XXXX A 0 A_CustomMissile ("CameraShake", 1, 0, random (0, 360), 2, random (0, 160))
+			  NULL A 0 A_PlaySound("CLAP")
+			CFTA EFF 7
+			CFTA GHIJK 2
+			  NULL A 0 A_PlaySound("grunt/pain")
+	NULL A 0 A_SpawnItemEx("FootStep5", 0, 0, 40, 0, 0)
+	NULL A 0 A_CustomMissile ("CameraShake", 50, 0, random (0, 360), 2, random (0, 160))
+	NULL A 0 A_CustomMissile ("GoreSound", 22, 0, random (0, 360), 2, random (0, 160))
+			 CFTA L 7
+			
+			CFTA M 15
+			CFTA OPQR 4
+			 NULL A 0 A_PlaySound("grunt/pain")
+			  NULL A 0 A_PlaySound("grunt/death")
+		   CFTA R 15
+			  NULL A 0 A_PlaySound("BURNZOM")
+	NULL A 0 A_CustomMissile ("CameraShake", 50, 0, random (0, 360), 2, random (0, 160))
+			 NULL AAAAAA 0 A_CustomMissile ("CeilBloodLauncher", 40, 0, random (0, 360), 2, random (50, 130))
+			 NULL AAAA 0 A_CustomMissile ("XDeath1", 10, 0, random (0, 360), 2, random (0, 160))
+			 NULL AAA 0 A_CustomMissile ("XDeath2", 10, 0, random (0, 360), 2, random (0, 160))
+			 NULL AAA 0 A_CustomMissile ("XDeath3", 10, 0, random (0, 360), 2, random (0, 160))
+			 NULL AAAAAAAAAA 0 A_CustomMissile ("PlayerFlyingBlood", 50, 0, random (0, 360), 2, random (0, 160))
+			CFTA S 25
+			//////////////////////////////////////////////////////
+			NULL A 0 A_TakeInventory("ComandoFatality",1)
+			NULL A 0 A_TakeInventory("GoFatality", 1)
+			NULL A 0 A_SpawnItemEx("DyingComando", 0, 0, 40, 0, 0)
+			TNT1 A 0 A_ChangeFlag (shootable, 1)
+		TNT1 A 0 A_ChangeFlag (Invulnerable, 0)
+			Goto See
+	
+	Salute:
+	TNT1 A 0
+	TNT1 A 0 A_Jump(255, "Salutes1", "Salutes2")
+	
+	Salutes1:
+	TNT1 A 0
+	    TNT1 A 0
+		TNT1 A 0 A_PlaySound ("DSSALUTE")
+        MWAV BCDEFEFDCB 6
+        Goto FollowPlayer
+
+    Salutes2:
+		TNT1 A 0
+		TNT1 A 0 A_PlaySound ("DSSALUTE")
+        MWAV GHGHG 8
+        Goto FollowPlayer
+	}
+}
+
+ACTOR RifleMarineGuarding: Marine_Rifle
+{
+	Speed 0
+	FastSpeed 0
+	MaxStepHeight 0
+	+FRIENDLY
+	+MISSILEMORE
+	+NODROPOFF
+	+MISSILEEVENMORE
+	States
+	{
+	Active:
+		TNT1 A 0 A_ChangeFlag("NOBLOCKMAP", 1)
+		MR7S A 30
+		TNT1 A 0 A_SpawnItemEx ("Marine_Rifle",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+		TNT1 A 0 A_CustomMissile ("OrderTitle1", 50, 0, 0, 2, 90)
+		TNT1 A 0 A_PlaySound("MarineFollow", 2)
+		Stop
+		
+	Spawn:
+		TNT1 A 0
+		TNT1 A 0 A_ChangeFlag("FRIENDLY", 1)
+		TNT1 A 0 A_GiveInventory("TargetIsAMarine")
+		MARN D 1 A_Look
+		Goto See
+		
+	See:	
+		//TNT1 A 0 A_SetAngle(random(90, -90) + angle)
+		TNT1 A 0 A_ChangeFlag("SHOOTABLE", 0)
+		TNT1 A 0 A_ChangeFlag("SOLID", 0)
+		MARN DDDDDDDDDD 1 A_Chase
+		TNT1 A 0 A_ClearTarget
+		Loop
+	
+	Missile:
+        //PLAY E 1
+		TNT1 A 0 A_ChangeFlag("FRIENDLY", 1)
+		TNT1 A 0 A_SpawnItem("KillMeSmall")
+		TNT1 A 0 A_JumpIfInTargetInventory("TargetIsACyberdemon", 1, "CheckRetreat")
+		TNT1 A 0 A_JumpIfInTargetInventory("TargetIsAMastermind", 1, "CheckRetreat")
+		TNT1 A 0 A_ChangeFlag("SHOOTABLE", 1)
+		//TNT1 A 0 A_ChangeFlag("SOLID", 1)
+		
+		TNT1 A 0 A_PlaySound("MRNAT", 2)
+	
+	PLAY E 6 A_FaceTarget
+        TNT1 A 0 A_CustomMissile("MarineMuzzle1", 34)
+        TNT1 A 0 A_PlaySound("weapons/rifle")
+		PLAY F 2 BRIGHT 
+		TNT1 A 0 A_CustomMissile("MarineTracer", 40, 0, 0, 0)
+		TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 30,0)
+	
+	PLAY E 2 A_FaceTarget
+        TNT1 A 0 A_CustomMissile("MarineMuzzle1", 34)
+        TNT1 A 0 A_PlaySound("weapons/rifle")
+		PLAY F 2 BRIGHT
+		TNT1 A 0 A_CustomMissile("MarineTracer", 40, 0, 0, 0)
+		TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 30,0)
+	
+	PLAY E 2 A_FaceTarget
+        TNT1 A 0 A_CustomMissile("MarineMuzzle1", 34)
+        TNT1 A 0 A_PlaySound("weapons/rifle")
+		PLAY F 2 BRIGHT
+		TNT1 A 0 A_CustomMissile("MarineTracer", 40, 0, 0, 0)
+		TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 30,0)
+		TNT1 A 0 A_CPosREfire
+		Goto See
+		
+	MissileLeft:
+        TNT1 A 0
+	
+	MARN A 2 A_FaceTarget
+		TNT1 A 0 ThrustThing(angle*256/360+192, 3, 0, 0)
+        TNT1 A 0 A_CustomMissile("MarineMuzzle1", 34)
+        TNT1 A 0 A_PlaySound("weapons/rifle")
+		MARN B 2 BRIGHT 
+		TNT1 A 0 A_CustomMissile("MarineTracer", 42, 0, 0, 0)
+		TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 30,0)
+	
+	TNT1 A 0 ThrustThing(angle*256/360+192, 3, 0, 0)
+		MARN C 2 A_FaceTarget
+        TNT1 A 0 A_CustomMissile("MarineMuzzle1", 34)
+        TNT1 A 0 A_PlaySound("weapons/rifle")
+		MARN B 2 BRIGHT
+		TNT1 A 0 A_CustomMissile("MarineTracer", 42, 0, 0, 0)
+		TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 30,0)
+	
+	MARN A 2 A_FaceTarget
+		TNT1 A 0 ThrustThing(angle*256/360+192, 3, 0, 0)
+        TNT1 A 0 A_CustomMissile("MarineMuzzle1", 34)
+        TNT1 A 0 A_PlaySound("weapons/rifle")
+		MARN B 2 BRIGHT 
+		TNT1 A 0 A_CustomMissile("MarineTracer", 42, 0, 0, 0)
+		TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 30,0)
+	
+	MARN C 2 A_FaceTarget
+		TNT1 A 0 ThrustThing(angle*256/360+192, 3, 0, 0)
+        TNT1 A 0 A_CustomMissile("MarineMuzzle1", 34)
+        TNT1 A 0 A_PlaySound("weapons/rifle")
+		MARN B 2 BRIGHT
+		TNT1 A 0 A_CustomMissile("MarineTracer", 42, 0, 0, 0)
+		TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 30,0)
+		Goto See
+	
+	MissileRight:
+        TNT1 A 0
+	
+	MARN A 2 A_FaceTarget
+		TNT1 A 0 ThrustThing(angle*256/360+64, 3, 0, 0)
+        TNT1 A 0 A_CustomMissile("MarineMuzzle1", 34)
+        TNT1 A 0 A_PlaySound("weapons/rifle")
+		MARN B 2 BRIGHT 
+		TNT1 A 0 A_CustomMissile("MarineTracer", 42, 0, 0, 0)
+		TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 30,0)
+	
+	TNT1 A 0 ThrustThing(angle*256/360+64, 3, 0, 0)
+		MARN C 2 A_FaceTarget
+        TNT1 A 0 A_CustomMissile("MarineMuzzle1", 34)
+        TNT1 A 0 A_PlaySound("weapons/rifle")
+		MARN B 2 BRIGHT
+		TNT1 A 0 A_CustomMissile("MarineTracer", 42, 0, 0, 0)
+		TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 30,0)
+		
+		MARN A 2 A_FaceTarget
+		TNT1 A 0 ThrustThing(angle*256/360+64, 3, 0, 0)
+        TNT1 A 0 A_CustomMissile("MarineMuzzle1", 34)
+        TNT1 A 0 A_PlaySound("weapons/rifle")
+		MARN B 2 BRIGHT 
+		TNT1 A 0 A_CustomMissile("MarineTracer", 42, 0, 0, 0)
+		TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 30,0)
+	
+	MARN C 2 A_FaceTarget
+		TNT1 A 0 ThrustThing(angle*256/360+64, 3, 0, 0)
+        TNT1 A 0 A_CustomMissile("MarineMuzzle1", 34)
+        TNT1 A 0 A_PlaySound("weapons/rifle")
+		MARN B 2 BRIGHT
+		TNT1 A 0 A_CustomMissile("MarineTracer", 42, 0, 0, 0)
+		TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 30,0)
+		TNT1 A 0 A_ChangeFlag("SHOOTABLE", 1)
+        Goto See	
+		
+	CheckRetreat:
+		TNT1 A 0
+		TNT1 A 0 A_JumpIfCloser(500, "Retreat")
+		TNT1 A 0 A_Jump(256, "MissileRight", "MissileLeft")
+		Goto MissileRight
+		
+	Retreat:
+        TNT1 A 0
+		MARN A 2 A_FaceTarget
+		TNT1 A 0 A_Recoil(4)
+        TNT1 A 0 A_CustomMissile("MarineMuzzle1", 34)
+        TNT1 A 0 A_PlaySound("weapons/rifle")
+		MARN B 2 BRIGHT 
+		TNT1 A 0 A_CustomMissile("MarineTracer", 42, 0, 0, 0)
+		TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 30,0)
+
+        TNT1 A 0 A_Recoil(4)
+		MARN C 2 A_FaceTarget
+        TNT1 A 0 A_CustomMissile("MarineMuzzle1", 34)
+        TNT1 A 0 A_PlaySound("weapons/rifle")
+		MARN B 2 BRIGHT
+		TNT1 A 0 A_CustomMissile("MarineTracer", 42, 0, 0, 0)
+		TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 30,0)
+		
+		MARN A 2 A_FaceTarget
+		TNT1 A 0 A_Recoil(4)
+        TNT1 A 0 A_CustomMissile("MarineMuzzle1", 34)
+        TNT1 A 0 A_PlaySound("weapons/rifle")
+		MARN B 2 BRIGHT 
+		TNT1 A 0 A_CustomMissile("MarineTracer", 42, 0, 0, 0)
+		TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 30,0)
+		
+		MARN C 2 A_FaceTarget
+		TNT1 A 0 A_Recoil(4)
+        TNT1 A 0 A_CustomMissile("MarineMuzzle1", 34)
+        TNT1 A 0 A_PlaySound("weapons/rifle")
+		MARN B 2 BRIGHT
+		TNT1 A 0 A_CustomMissile("MarineTracer", 42, 0, 0, 0)
+		TNT1 A 0 A_SpawnItem ("RifleCaseSpawn", 0, 30,0)
+		TNT1 A 0 A_Jump(128, "MissileRight", "MissileLeft")
+		Goto See
+	
+	Pain.Kick:
+		PLAY A 2 A_FaceTarget
+		TNT1 A 0 A_Recoil(5)
+        Goto See
+	
+	Pain:
+	    PLAY G 3
+		PLAY G 3 A_Pain
+		TNT1 A 0 A_Jump(128, "MissileLeft", "MissileRight")
+		Goto See
+	}
+}
+
+ACTOR Ally: DeadMarine
+{
+	Game Doom
+	States
+	{
+    Spawn:
+		TNT1 A 0
+		TNT1 A 0 A_Jump(192,"Spawn2","Spawn2","Spawn3","Spawn4","Spawn4","Spawn5","Spawn6","Spawn7","Spawn8","Spawn8")
+		TNT1 A 1 A_SpawnItem("Marine",0,0,0,0)
+		Stop
+
+   Spawn2:
+		TNT1 A 1 A_SpawnItem("MarineShotgun",0,0,0,0)
+		Stop
+
+   Spawn3:
+		TNT1 A 1 A_SpawnItem("MarineSSG",0,0,0,0)
+		Stop
+
+   Spawn4:
+		TNT1 A 1 A_SpawnItem("MarineChaingun",0,0,0,0)
+		Stop
+
+   Spawn5:
+		TNT1 A 1 A_SpawnItem("MarinePlasma",0,0,0,0)
+		Stop
+
+   Spawn6:
+		Goto Spawn
+		Stop
+
+   Spawn7:
+		TNT1 A 1 A_SpawnItem("MarineRocket",0,0,0,0)
+		Stop
+
+   Spawn8:
+		TNT1 A 1 A_SpawnItem("Marine",0,0,0,0)
+		Stop
+
+    Death:
+        Stop
+	}
+}
+
+ACTOR Marine1Pathfinder
+{
+	Radius 32
+	Height 56
+	Speed 20
+	Health 4000
+	PainChance 255
+	MaxTargetRange 150
+	Monster
+	damagefactor "SpawnMarine", 8000.0
+	MaxDropOffHeight 1200
+	MaxStepHeight 1200
+	-COUNTKILL
+	+NOTARGET
+	+THRUACTORS
+	+MISSILEMORE
+	+MISSILEEVENMORE
+	+FASTER
+    +DONTSPLASH
+	-SHOOTABLE
+	-FRIENDLY
+	+NOCLIP
+	+LOOKALLAROUND
+	+NOINFIGHTING
+	States
+	{
+	Spawn:
+	Pain:
+    See:
+		TNT1 A 0 A_ChangeFlag("FRIENDLY", 0)
+		TNT1 A 0 A_ChangeFlag("NOCLIP", 1)
+		//TNT1 A 0 Thing_ChangeTID(0,98)
+		//TNT1 A 0 Thing_Hate(98, 0, 0)
+		TNT1 A 0
+		TNT1 A 0 A_GiveInventory("TargetIsAMarine", 1)
+		TNT1 AAAAA 1 A_Chase
+		//TNT1 A 0 Thing_Hate(98, 0, 0)
+		TNT1 A 0
+		TNT1 A 0 A_GiveInventory("TargetIsAMarine", 1)
+		TNT1 A 1 A_FaceTarget
+		Loop
+
+	Missile:
+	    TNT1 A 0
+		TNT1 A 0 A_ChangeFlag("NOCLIP", 0)
+	    TNT1 A 0 A_Recoil(-4)
+		TNT1 A 1
+		TNT1 A 0 A_JumpIf(momx == 0, "CheckAgain")
+	SpawnMarine:	
+		TNT1 A 0 A_Scream
+		TNT1 A 0 A_NoBlocking
+		TNT1 A 0 A_SpawnItemEx("Marine_Rifle",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+		TNT1 A 0 A_SpawnItem("FriendlymarineTFog")
+		Stop
+	CheckAgain:
+		TNT1 A 0
+		TNT1 A 0 A_JumpIF(momy == 0, "See")
+		Goto SpawnMarine
+	}
+}
+
+ACTOR Marine1PathfinderNew: Marine1Pathfinder
+{
+-FRIENDLY
+	Speed 4
+	States
+	{
+	Spawn:
+	TNT1 A 0
+	TNT1 A 0 A_GiveInventory("TargetIsAMarine", 1)
+	Goto See
+	Pain:
+    See:
+		TNT1 A 0 A_ChangeFlag("FRIENDLY", 0)
+		TNT1 A 0 Thing_ChangeTID(0,98)
+		TNT1 AAAAAAAAAAAAAAAAA 1 A_Chase
+		//TNT1 A 0 Thing_Hate(98, 264, 0)
+		TNT1 A 0 A_Recoil(-5)
+		TNT1 A 0 A_SpawnItem("MarineSpawnChecker")
+		TNT1 A 1 A_FaceTarget
+		Loop
+	Death:
+	Missile:
+		TNT1 A 0
+	    TNT1 A 0 A_Recoil(-2)
+		TNT1 A 1
+		TNT1 A 0 A_Scream
+		TNT1 A 0 A_NoBlocking
+		TNT1 A 0 A_SpawnItemEx("Marine_Rifle",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+		//TNT1 A 0 A_SpawnItemEx("MarineAdd",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+		TNT1 A 0 A_SpawnItem("FriendlymarineTFog")
+		Stop
+	}
+}
+
+ACTOR MarineAdd: Marine1Pathfinder
+{
+	Speed 4
+	States
+	{
+	Spawn:
+	TNT1 A 0
+	TNT1 A 0 A_GiveInventory("TargetIsAMarine", 1)
+	Goto See
+	Pain:
+    See:
+		TNT1 A 0 A_ChangeFlag("FRIENDLY", 0)
+		TNT1 A 0 Thing_ChangeTID(0,98)
+		TNT1 AAAAAAAAAAAAAAAAA 1 A_Chase
+		//TNT1 A 0 Thing_Hate(98, 264, 0)
+		TNT1 A 0 A_Recoil(-5)
+		TNT1 A 1 A_FaceTarget
+		Loop
+	Death:
+	Missile:
+		TNT1 A 1
+		TNT1 A 0 A_Scream
+		TNT1 A 0 A_NoBlocking
+		TNT1 A 200
+		TNT1 A 0 A_GiveToTarget("NumberOfAllies", 1)
+		Stop
+	}
+}
+
+ACTOR RemoveMarine
+{
+	States
+	{
+	Spawn:
+	Pain:
+    See:
+		TNT1 A 1
+		TNT1 A 0 A_SpawnItemEx("RemoveMarineActivate",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+		TNT1 A 1
+		Stop
+	}
+}
+
+ACTOR RemoveMarineActivate: Marine1Pathfinder
+{
+-FRIENDLY
+-SHOOTABLE
+Scale 1.0
+Speed 1
+MaxTargetRange 90000
+	States
+	{
+	Spawn:
+	Pain:
+    See:
+		TNT1 A 0 A_ChangeFlag("FRIENDLY", 0)
+		TNT1 A 0 Thing_ChangeTID(0,98)
+		TNT1 AAAAAAAAAAAAAAAAA 1 A_Chase
+		//TNT1 A 0 Thing_Hate(98, 264, 0)
+		TNT1 A 0 A_Recoil(-5)
+		TNT1 A 1 A_FaceTarget
+		Loop
+	Missile:
+		TNT1 A 1
+		TNT1 A 0 A_TakeFromTarget("NumberOfAllies", 1)
+		TNT1 A 0 A_Scream
+		TNT1 A 0 A_NoBlocking
+		TNT1 A 1
+		Stop
+	}
+}
+
+ACTOR MarineSpawnChecker
+{
+MONSTER
+-COUNTKILL
++FRIENDLY
+-SOLID
+-SHOOTABLE
+Health 1
+Radius 16
+Height 52
+Damagetype "SpawnMarine"
+	States
+	{
+	Spawn:
+	    TNT1 A 0
+	TNT1 A 0 A_GiveInventory("TargetIsAMarine", 1)
+	    TNT1 A 0 A_AlertMonsters
+		TNT1 A 0 A_Explode(25, 40)
+		Stop
+	Death:
+	TNT1 A 1
+	Stop
+}
+}

--- a/MARINES.txt
+++ b/MARINES.txt
@@ -108,6 +108,10 @@ ACTOR Marine_Rifle: SwitchableDecoration
 	Game Doom
 	Health 100
 	PainChance 255
+	DamageFactor "Melee", 0.0	DamageFactor "Minor", 0.0	DamageFactor "Kick", 0.0
+	DamageFactor "ExplosiveImpact", 0.0	DamageFactor "Bullet", 0.0	DamageFactor "SSG", 0.0
+	DamageFactor "Shotgun", 0.0	DamageFactor "Shrapnel", 0.0	DamageFactor "Minigun", 0.0
+	DamageFactor "Railgun", 0.0	DamageFactor "Extreme", 0.0
 	Damagefactor "Avoid", 0.0	Damagefactor "BHFTOnBarrel", 0.0	Damagefactor "Blood", 0.0
 	Damagefactor "CancelTeleportFog", 0.0	Damagefactor "CauseWaterSplash", 0.0	Damagefactor "Crush", 10.0
 	Damagefactor "Cut", 0.0	Damagefactor "Extremepunches", 0.0	Damagefactor "Fatality", 0.0

--- a/PUFF.txt
+++ b/PUFF.txt
@@ -11,6 +11,8 @@ DamageType Melee
   +BLOODLESSIMPACT 
   +FORCEXYBILLBOARD
   +DONTSPLASH
+  +MTHRUSPECIES
+  Species "Marines"
   states
   {
   Spawn:
@@ -124,9 +126,11 @@ ACTOR HitPuff Replaces BulletPuff
 	+FORCEXYBILLBOARD
 	+DONTSPLASH
 	-EXPLODEONWATER
+	+MTHRUSPECIES
 	Gravity 0.01
 	DamageType Bullet
 	Decal "BulletDecalNew1"
+	Species "Marines"
   states
   {
   Spawn:

--- a/PUFF.txt
+++ b/PUFF.txt
@@ -1,28 +1,26 @@
 ACTOR MeleePuff: BulletPuff
 {
-  renderstyle Translucent
-  alpha 0.5
-  Scale 1.5
-DamageType Melee
-  +NOBLOCKMAP
-  +NOGRAVITY
-  +NOEXTREMEDEATH
-  +PUFFONACTORS
-  +BLOODLESSIMPACT 
-  +FORCEXYBILLBOARD
-  +DONTSPLASH
-  +MTHRUSPECIES
-  Species "Marines"
-  states
-  {
-  Spawn:
-  Death:
-  Melee:
-  XDeath:
-    PUFF A 0 A_PlaySound("player/cyborg/fist")
-    EXPL AAAAAA 0 A_CustomMissile ("MeleeSmoke", 0, 0, random (0, 360), 2, random (0, 360))
+	renderstyle Translucent
+	alpha 0.5
+	Scale 1.5
+	DamageType Melee
+	+NOBLOCKMAP
+	+NOGRAVITY
+	+NOEXTREMEDEATH
+	+PUFFONACTORS
+	+BLOODLESSIMPACT 
+	+FORCEXYBILLBOARD
+	+DONTSPLASH
+	states
+	{
+	Spawn:
+	Death:
+	Melee:
+	XDeath:
+	PUFF A 0 A_PlaySound("player/cyborg/fist")
+	EXPL AAAAAA 0 A_CustomMissile ("MeleeSmoke", 0, 0, random (0, 360), 2, random (0, 360))
 	TNT1 A 10
-    stop
+	stop
  
   }
 }
@@ -126,11 +124,9 @@ ACTOR HitPuff Replaces BulletPuff
 	+FORCEXYBILLBOARD
 	+DONTSPLASH
 	-EXPLODEONWATER
-	+MTHRUSPECIES
 	Gravity 0.01
 	DamageType Bullet
 	Decal "BulletDecalNew1"
-	Species "Marines"
   states
   {
   Spawn:


### PR DESCRIPTION
Reordered the Marine's Active state to try and prevent duplicate spawns online when telling them to guard or follow (worked during test hosting on personal computer).  And added species "Marines" and +MTHRUSPECIES to MeleePuff and HitPuff so that marines will quit blocking the players shots when they become shootable.

Closes #44 