### PR TITLE
Reload state goto fixes

### DIFF
--- a/DualMP40.txt
+++ b/DualMP40.txt
@@ -212,7 +212,7 @@ ACTOR DualMP40 : BrutalWeapon
 		MP42 A 0 A_JumpIfInventory("DualMP40Ammo",64,"Ready")
 
         MP42 A 0 A_JumpIfInventory("Mauser9mm",1,3)
-        Goto NoAmmo
+        Goto Ready
         TNT1 AAA 0
 		MP42 A 0 A_JumpIfInventory("TurboReload",1,"TurboReload")
 		MP42 F 1

--- a/DualPistol.txt
+++ b/DualPistol.txt
@@ -328,7 +328,7 @@ ACTOR DualPistols : BrutalWeapon
 		PI2G A 0 A_JumpIfInventory("BDDualPistolAmmo",32,"Ready")
 
         PI2G A 0 A_JumpIfInventory("Clip1",1,3)
-        Goto NoAmmo
+        Goto Ready
         TNT1 AAA 0
 		PI2G A 0 A_JumpIfInventory("TurboReload",1,"TurboReload")
 		

--- a/DualRifle.txt
+++ b/DualRifle.txt
@@ -271,7 +271,7 @@ ACTOR DualRifles : BrutalWeapon
 		DURI A 0 A_JumpIfInventory("DoubleRifleAmmo",62,76)
 		DURI A 0 A_JumpIfInventory("TurboReload",1,"TurboReload")
         DURI A 0 A_JumpIfInventory("Clip2",1,3)
-        Goto NoAmmo
+        Goto Ready
         TNT1 AAA 0
 		DURI A 0 A_JumpIfInventory("TurboReload",1,"TurboReload")
 		DURI A 0

--- a/DualSMG.txt
+++ b/DualSMG.txt
@@ -220,7 +220,7 @@ ACTOR DualSMG : BrutalWeapon
 		SM2G A 0 A_JumpIfInventory("BDDualSMGAmmo",82,"Ready")
 
         SM2G A 0 A_JumpIfInventory("Clip1",1,3)
-        Goto NoAmmo
+        Goto Ready
         TNT1 AAA 0
 		SM2G A 0 A_JumpIfInventory("TurboReload",1,"TurboReload")
 		SM2S CBA 1

--- a/ExpansionChangelog.txt
+++ b/ExpansionChangelog.txt
@@ -17,6 +17,10 @@
 //	DEFAULTWEAPON.txt:				Changed the GoingToReady state to reset the crosshair only
 //									Added +NONETID to FlashLightProjectile
 //	Demons.txt:						Changed the Death.Plasma state to spawn "BurnedDemon" at the end
+//	DualMP40.txt:					Changed Reload state to jump to Ready if there is no reserve ammo instead of NoAmmo
+//	DualPistol.txt:					Changed Reload state to jump to Ready if there is no reserve ammo instead of NoAmmo
+//	DualRifle.txt:					Changed Reload state to jump to Ready if there is no reserve ammo instead of NoAmmo
+//	DualSMG.txt:					Changed Reload state to jump to Ready if there is no reserve ammo instead of NoAmmo
 //	+EvilMarineShield.txt:			Polished states to make the weapon more functional
 //	Fire.txt:						Created temp actors that will extinguish after 30 seconds
 //	Heady_Sys.txt:					Duplicated the headshot actor's various pain states for the meatshield actor
@@ -27,12 +31,18 @@
 //	+Natural.txt:					Added in extinguish states and timed-burn feature
 //	+NaziShield.txt:				Polished states to make the weapon more functional
 //	Pistol.txt:						Updated the pistol's FireEndTactical states to be consistent with previous edits
+//									Changed Reload state to jump to Ready if there is no reserve ammo instead of NoAmmo
+//	Plasma.txt:						Changed Reload state to jump to Ready if there is no reserve ammo instead of NoAmmo
 //	Puff.txt:						Changed SSawPuff2 to DamageType Saw and Decal SawVertical
 //	Repairs.txt:					Created Extinguish states for vehicle corpses so that they will only burn for 30 seconds
+//	Revolver.txt:					Changed Reload state to jump to Ready if there is no reserve ammo instead of NoAmmo
+//	Revolver2.txt:					Changed Reload state to jump to Ready if there is no reserve ammo instead of NoAmmo
+//	Rifle.txt:						Changed Reload state to jump to Ready if there is no reserve ammo instead of NoAmmo
 //	Saw.txt:						Polished Deslect state, Weapon now does 20 damage / 4 tics
 //	SGuyShield.txt:					Polished states to make the weapon more functional
 //	SpecialDoom1Bosses.txt:			Moved the A_ChangeFlags before the A_Pain line to prevent pain-locking
 //	Spiders2.txt:					Added the Idle state label to the Spawn State
+//	SubMachinegun.txt:				Changed Reload state to jump to Ready if there is no reserve ammo instead of NoAmmo
 //	Tracers.txt:					Changed MeatShieldTracer damage to 14 and added +MTHRUSPECIES so it will pass through the meatshield
 //	ZManShield.txt:					Polished states to make the weapon more functional
 //	+ZombieCivilianSheild.txt:		Polished states to make the weapon more functional

--- a/Pistol.txt
+++ b/Pistol.txt
@@ -275,7 +275,7 @@ ACTOR BrutalPistol : BrutalWeapon
 		PIST F 0 A_JumpIfInventory("BDPistolAmmo",16,"Ready")
 
         PIST F 0 A_JumpIfInventory("Clip1",1,3)
-        Goto NoAmmo
+        Goto Ready
         TNT1 AAA 0
 		PIST F 0 A_JumpIfInventory("TurboReload",1,"TurboReload")
 		PIST F 0 A_JumpIfInventory("HasUnloaded", 1, 3)

--- a/Plasma.txt
+++ b/Plasma.txt
@@ -405,13 +405,9 @@ AltHold:
 		PLSN A 0 A_Takeinventory("Reloading",1)
 		PLSN A 0 A_ClearReFire
 		PLSN A 0 A_JumpIfInventory("PlasmaAmmo",50,"Ready")
-		PLSN A 0 A_JumpIfInventory("AmmoCell",1,7)
-
+		PLSN A 0 A_JumpIfInventory("AmmoCell",1,3)
 		PLSN A 0 A_PlaySound("BEP")
-		PLSR A 4 BRIGHT A_WeaponReady(WRF_NOFIRE)
-		PLSN A 0 A_PlaySound("BEP")
-		PLSR A 4 BRIGHT A_WeaponReady(WRF_NOFIRE)
-		PLSN A 0 A_CheckReload
+		PLSR A 4 BRIGHT
         Goto Ready
         TNT1 AAAA 0
         PLSN A 0 A_PlaySound("PLREADY")

--- a/Revolver.txt
+++ b/Revolver.txt
@@ -256,7 +256,7 @@ ACTOR Revolver : BrutalWeapon 5874
 	    REVO A 0
 		REVO A 0 A_TakeInventory("Reloading", 1)
 		REVO A 0 A_JumpIfInventory("AmmoMagnum", 1, 2)
-		Goto NoAmmo
+		Goto Ready
 		REVO A 0
 	    REVO A 0 A_Takeinventory("Zoomed",1)
         REVO A 0 A_ZoomFactor(1.0)

--- a/Revolver2.txt
+++ b/Revolver2.txt
@@ -263,7 +263,7 @@ ACTOR Revolver2 : BrutalWeapon
 	    REVO A 0
 		REVO A 0 A_TakeInventory("Reloading", 1)
 		REVO A 0 A_JumpIfInventory("AmmoShell", 1, 2)
-		Goto NoAmmo
+		Goto Ready
 		REVO A 0
 	    REVO A 0 A_Takeinventory("Zoomed",1)
         REVO A 0 A_ZoomFactor(1.0)

--- a/Rifle.txt
+++ b/Rifle.txt
@@ -351,10 +351,10 @@ ACTOR Rifle : BrutalWeapon
 		RIFG A 0 A_Takeinventory("ADSmode",1)
 		RIFG A 0 A_Takeinventory("Zoomed",1)
 		RIFG A 0 A_SetCrosshair(0)
-		RIFG A 0 A_JumpIfInventory("RifleAmmo",31,76)
+		RIFG A 0 A_JumpIfInventory("RifleAmmo",31,"InsertBullets2")
 		RIFG A 0 A_JumpIfInventory("TurboReload",1,"TurboReload")
         RIFG A 0 A_JumpIfInventory("Clip2",1,3)
-        Goto NoAmmo
+        Goto Ready
         TNT1 AAA 0
 		RIFG A 0 A_Takeinventory("Zoomed",1)
         RIFG A 0 A_PlaySound("Reload", 6)

--- a/SubMachinegun.txt
+++ b/SubMachinegun.txt
@@ -296,7 +296,7 @@ ACTOR BrutalSMG : BrutalWeapon
 		SMGG A 0 A_JumpIfInventory("BDSMGAmmo",41,"Ready")
 
         SMGG A 0 A_JumpIfInventory("Clip1",1,3)
-        Goto NoAmmo
+        Goto Ready
         TNT1 AAA 0
 		SMGG A 0 A_JumpIfInventory("TurboReload",1,"TurboReload")
 		SMGG A 0 A_JumpIfInventory("HasUnloaded", 1, 2)


### PR DESCRIPTION
Changed the reload state to goto Ready if there is no reserve ammo instead of the NoAmmo state which disables firing for weapons that can still have ammo in their magazines.

Closes #126 