### PR TITLE
Remove +THRUGHOST

### DIFF
--- a/Baron.txt
+++ b/Baron.txt
@@ -6,7 +6,7 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 	Health 1200
 	+QUICKTORETALIATE
 	PainSound "PSXDPN"
-	
+
 	Damagefactor "Avoid", 0.0	Damagefactor "BHFTOnBarrel", 0.0	Damagefactor "Blood", 0.0
 	Damagefactor "CancelTeleportFog", 0.0	Damagefactor "CauseWaterSplash", 0.0	Damagefactor "Crush", 10.0
 	Damagefactor "GibRemoving", 0.0	Damagefactor "Glass", 0.0	Damagefactor "HangingHook", 0.0
@@ -19,7 +19,7 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 	Damagefactor "Trample", 0.5	Damagefactor "Slide", 0.5
 	Damagefactor "Burn", 0.5	Damagefactor "Fire", 0.5	Damagefactor "Flames", 0.5
 	Damagefactor "GreenFire", 0.5	Damagefactor "HumanBBQ", 0.5
-	
+
 	PainChance "Head", 255	PainChance "Taunt", 255	PainChance "Extremepunches", 16
 	PainChance "Fatality", 16	PainChance "HelperMarineFatallity", 16	PainChance "Kick", 255
 	PainChance "LowKick", 16	PainChance "Melee", 16	PainChance "MonsterKnocked", 16
@@ -27,7 +27,7 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 	PainChance "Burn", 16	PainChance "Fire", 16	PainChance "Flames", 16
 	PainChance "GreenFire", 16	PainChance "HumanBBQ", 16
 	PainChance "CallingTheBaronAFaggot", 255
-	
+
     BloodType "Green_Blood", "GreenSawBlood", "GreenSawBlood"
 	BloodColor "DarkGreen"
 	Obituary "%o was brutalized by a Baron of Hell."
@@ -44,43 +44,43 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 	DropItem "DemonRuneMix", 16
 	States
 	{
-	
+
 	ReplaceVanilla:
 		TNT1 A 0
 		TNT1 A 0 A_NoBlocking
 		TNT1 A 0 A_ChangeFlag("THRUACTORS", 1)
 		TNT1 A 0 A_ChangeFlag("COUNTKILL", 0)
 		TNT1 A 0 A_SpawnItemEx ("VanillaBaronOfHell",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION | SXF_TRANSFERAMBUSHFLAG | SXF_CLEARCALLERTID,tid)
-		TNT1 A 10 
+		TNT1 A 10
 		TNT1 A 1 A_BossDeath
 		TNT1 A 0 A_Die("Vanish")
 		Stop
-	
+
 	Death.Vanish:
 		TNT1 A 0
 		TNT1 A 0 A_NoBlocking
 		Stop
-		
+
 	ReplaceForBoss1:
 		TNT1 A 0
 		TNT1 A 0 A_NoBlocking
 		TNT1 A 0 A_ChangeFlag("THRUACTORS", 1)
 		TNT1 A 0 A_ChangeFlag("COUNTKILL", 0)
 		TNT1 A 0 A_SpawnItemEx ("BaronBoss1",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION | SXF_TRANSFERAMBUSHFLAG ,tid)
-		TNT1 A 10 
+		TNT1 A 10
 		TNT1 A 1 A_BossDeath
 		TNT1 A 0 A_Fall
-		Stop	
-		
+		Stop
+
 	ReplaceForBoss2:
 		TNT1 A 0
 		TNT1 A 0 A_NoBlocking
 		TNT1 A 0 A_ChangeFlag("THRUACTORS", 1)
 		TNT1 A 0 A_ChangeFlag("COUNTKILL", 0)
 		TNT1 A 0 A_SpawnItemEx ("BaronBoss2",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION | SXF_TRANSFERAMBUSHFLAG ,tid)
-		TNT1 A 10 
+		TNT1 A 10
 		TNT1 A 1 A_BossDeath
-		Stop		
+		Stop
     Spawn:
 		BARO B 0
 		TNT1 A 0 A_JumpIfInventory("Curbstomp_Marine", 1, "CurbstompMarine")
@@ -94,22 +94,23 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 		TNT1 A 0 ACS_NamedExecuteAlways("BDCHeckClassicMonsters", 0, 0, 0, 0)//Check if Vanilla Mode is activated
 		TNT1 A 0 A_Jump(4, "ReplaceBelphegor")
 		Goto Stand
-		
+
 	ReplaceBelphegor:
 		TNT1 A 0 A_JumpIf((CeilingZ - FloorZ) < 93,"Stand")
 		TNT1 A 0 A_ChangeFlag("THRUACTORS", 1)
 		TNT1 A 0 A_ChangeFlag("COUNTKILL", 0)
 		TNT1 A 0 A_SpawnItemEx ("Belphegor2",0,0,0,0,0,0,0, SXF_NOCHECKPOSITION | SXF_TRANSFERAMBUSHFLAG | SXF_TRANSFERPOINTERS ,0, tid)
 		Stop
-		
+
 	Stand:
 		TNT1 A 0
 		TNT1 A 0 A_CheckSight("Stand2")
 		BTS3 A 0 A_SpawnItem("HeadshotTarget20b", 0, 58)
 		BARO BB 10 A_Look
 		Loop
-		
+
 	Stand2:
+		BTS3 A 0 A_SpawnItem("HeadshotTarget10b", 0, 58)
 		BARO B 10 A_Look
 		Goto Stand
 	See:
@@ -118,14 +119,14 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 		TNT1 A 0 A_JumpIfInventory("HasExplosiveBarrel", 1, "MissileBarrel")
 	    TNT1 A 0 A_SpawnItem("HeadshotTarget4b", 0, 58)
 		BARO A 1
-        BTS3 ABC 1 
+        BTS3 ABC 1
 		TNT1 A 0 A_FaceTarget
 		TNT1 A 0 A_SpawnItem("HeadshotTarget6b", 0, 58)
 		BTS3 D 4
 		BTS3 CBA 1
 		//TNT1 A 0 HealThing(200)
 		Goto See2
-	
+
 	See2:
 		TNT1 A 0
 		TNT1 A 0 A_JumpIfInventory("Curbstomp_Marine", 1, "CurbstompMarine")
@@ -144,13 +145,13 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
         //TNT1 A 0 A_SpawnItemEx("FootSep", 0, 0)
 		TNT1 A 0 A_SpawnItem("HeadshotTarget6b", 0, 58)
 		BARO AAA 2 A_Chase
-		
+
 		TNT1 A 0 A_SpawnItem("HeadshotTarget6b", 0, 58)
 		BARO BBB 2 A_Chase
-		
+
 		TNT1 A 0 A_SpawnItem("HeadshotTarget6b", 0, 58)
 		BARO CCC 2 A_Chase
-		
+
 		TNT1 A 0 A_SpawnItem("HeadshotTarget6b", 0, 58)
 		BARO DDD 2 A_Chase
 
@@ -158,7 +159,7 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 		TNT1 A 0 A_JumpIfInTargetInventory("TargetIsAMastermind", 1, "CheckRetreat")
 		TNT1 A 0 A_JumpIfInTargetInventory("IsInvisible", 1, "ForgetTarget")
 		Loop
-		
+
 	SeeNeverSeen:
 		TNT1 A 0
 		BARO A 0 A_CheckSight("SEE3")
@@ -168,7 +169,7 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 		BARO AA 2 A_Chase
 		TNT1 A 0 A_SpawnItem("HeadshotTarget4b", 0, 58)
 		BARO AA 2 A_Chase
-		
+
 		TNT1 A 0 A_SpawnItem("HeadshotTarget4b", 0, 58)
 		BARO B 4 A_Chase
 		TNT1 A 0 A_SpawnItem("HeadshotTarget4b", 0, 58)
@@ -180,18 +181,18 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 		BARO CC 2 A_Chase
 		TNT1 A 0 A_SpawnItem("HeadshotTarget4b", 0, 58)
 		BARO DD 2 A_Chase
-		
+
 		TNT1 A 0 A_SpawnItem("HeadshotTarget4b", 0, 58)
 		BARO DD 2 A_Chase
 		TNT1 A 0 A_JumpIfInTargetInventory("TargetIsACyberdemon", 1, "CheckRetreat")
 		TNT1 A 0 A_JumpIfInTargetInventory("TargetIsAMastermind", 1, "CheckRetreat")
 		TNT1 A 0 A_JumpIfInTargetInventory("IsInvisible", 1, "ForgetTarget")
-		Loop	
+		Loop
 	See3:
         //TNT1 A 0 A_SpawnItemEx("FootSep", 0, 0)
 		BARO AABBCCDD 3 A_Chase
 		Goto See4
-		
+
 	Idle:
 	LookingForPlayer:
 	    TNT1 A 0 A_GiveInventory("SKImp", 1)
@@ -215,22 +216,22 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 		BARO B 10 A_Look
         TNT1 A 0 A_SpawnItem ("HeadshotTarget10b", 0, 58)
 		BARO B 10 A_Look
-		
+
 		BARO A 0 A_Wander
 		BARO AA 2 A_Look
 		TNT1 A 0 A_Recoil(-2)
 		TNT1 A 0 A_SpawnItem("HeadshotTarget6b", 0, 58)
-		
+
 		BARO B 0 A_Wander
 		BARO BB 2 A_Look
 		TNT1 A 0 A_Recoil(-2)
 		TNT1 A 0 A_SpawnItem("HeadshotTarget6b", 0, 58)
-		
+
 		BARO C 0 A_Wander
 		BARO CC 2 A_Look
 		TNT1 A 0 A_Recoil(-2)
 		TNT1 A 0 A_SpawnItem("HeadshotTarget6b", 0, 58)
-		
+
 		BARO D 0 A_Wander
 		BARO DD 2 A_Look
 		TNT1 A 0 A_Recoil(-2)
@@ -242,17 +243,17 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 		BARO AA 2 A_Look
 		TNT1 A 0 A_Recoil(-2)
 		TNT1 A 0 A_SpawnItem("HeadshotTarget6b", 0, 58)
-		
+
 		BARO B 0 A_Wander
 		BARO BB 2 A_Look
 		TNT1 A 0 A_Recoil(-2)
 		TNT1 A 0 A_SpawnItem("HeadshotTarget6b", 0, 58)
-		
+
 		BARO C 0 A_Wander
 		BARO CC 2 A_Look
 		TNT1 A 0 A_Recoil(-2)
 		TNT1 A 0 A_SpawnItem("HeadshotTarget6b", 0, 58)
-		
+
 		BARO D 0 A_Wander
 		BARO DD 2 A_Look
 		TNT1 A 0 A_Recoil(-2)
@@ -276,10 +277,10 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 		TNT1 A 0 HealThing(200)
 		TNT1 A 0 A_Jump(96, "SpecialAttack")
 		Goto See2
-	
+
 	Melee:
 	    TNT1 A 0
-		
+
 	    TNT1 A 0 A_JumpIfInTargetInventory("TargetIsACyberdemon", 1, "CheckRetreat")
 		TNT1 A 0 A_JumpIfInTargetInventory("TargetIsAMastermind", 1, "CheckRetreat")
 		TNT1 A 0 A_FaceTarget
@@ -287,7 +288,7 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 58)
 		BARO E 1
 		TNT1 A 0 A_JumpIfInventory("HasExplosiveBarrel", 1, "MissileBarrel")
-		
+
         BARO E 6
         TNT1 A 0 A_PlaySound("weapons/gswing")
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 58)
@@ -295,12 +296,12 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 58)
 		BARO G 6 A_CustomMissile("BaronAttack",10,0,0,0)
 		TNT1 A 0 A_JumpIfInventory("Curbstomp_Marine", 1, "CurbstompMarine")
-		TNT1 A 0 A_JumpIfInventory("ZombiemanFatality", 1, "FatalityZombieman")		
+		TNT1 A 0 A_JumpIfInventory("ZombiemanFatality", 1, "FatalityZombieman")
 		Goto See2
-		
+
 	Melee2:
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 58)
-		
+
 		BARO E 6 A_FaceTarget
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 58)
 		BARO F 6 A_FaceTarget
@@ -312,10 +313,10 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 		TNT1 A 0 A_JumpIfInventory("DemonFatality", 1, "FatalityDemon")
 		TNT1 A 0 A_JumpIfInventory("ImpFatality3", 1, "FatalityImp")
 		Goto See2
-	
+
     Missile:
 		BARO A 1
-		
+
 		TNT1 A 0 A_TakeInventory("EnemyMemory", 30)
 		TNT1 A 0 A_JumpIfInTargetInventory("TargetIsACyberdemon", 1, "CheckRetreat")
 		TNT1 A 0 A_JumpIfInTargetInventory("TargetIsAMastermind", 1, "CheckRetreat")
@@ -324,15 +325,15 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 		TNT1 A 0 A_JumpIfInventory("Curbstomp_Marine", 1, "CurbstompMarine")
 		TNT1 A 0 A_JumpIfInventory("ZombiemanFatality", 1, "FatalityZombieman")
 		TNT1 A 0 A_JumpIfInTargetInventory ("TypeZombieman", 1, "See2")
-		TNT1 A 0 A_JumpIfInTargetInventory ("TypeSergeant", 1, "See2") 
-        
+		TNT1 A 0 A_JumpIfInTargetInventory ("TypeSergeant", 1, "See2")
+
 		//TNT1 A 0 A_JumpIfInTargetInventory("IsPlayer", 0, 5)
 		//TNT1 A 0 A_TakeInventory("CantFire", 1)
-		//TNT1 A 0 A_CustomMissile("MonsterTargetCheck", 34, 0, 0, 0) 
-		//TNT1 A 0 A_CustomMissile("MonsterTargetCheckFaster", 34, 0, 0, 0)  
+		//TNT1 A 0 A_CustomMissile("MonsterTargetCheck", 34, 0, 0, 0)
+		//TNT1 A 0 A_CustomMissile("MonsterTargetCheckFaster", 34, 0, 0, 0)
 		BARO e 3 A_FaceTarget
 		//TNT1 A 0 A_JumpIfInventory("CantFire",1, "See4")
-		
+
 		TNT1 A 0 A_Jump (64, "SpecialAttack")
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 58)
 		BARO E 2 A_FaceTarget
@@ -350,7 +351,7 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 		TNT1 A 0 bright A_CustomMissile ("SmallGreenFlameTrails", 78, 40, random (0, 360), 2, random (70, 110))
 		TNT1 A 0 A_CustomMissile ("BallGettingReadyGreen", 79, 40, random (0, 140), 2, random (0, 160))
 		BARO E 2 A_FaceTarget
-		
+
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 58)
 		BARO F 3 A_FaceTarget
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 58)
@@ -362,7 +363,7 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 
     SpecialAttack:
 	    TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 58)
-		
+
 		BARO R 3 A_FaceTarget
 	    TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 58)
 		BARO Q 6 A_FaceTarget
@@ -390,7 +391,7 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 		TNT1 A 0 bright A_CustomMissile ("SmallGreenFlameTrails", 78, -40, random (0, 360), 2, random (70, 110))
 		TNT1 A 0 A_CustomMissile ("BallGettingReadyGreen", 79, -40, random (0, 140), 2, random (0, 160))
 		BARO P 2 A_FaceTarget
-		
+
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 58)
 		BARO Q 4 A_FaceTarget
 		TNT1 A 0 bright A_CustomMissile ("SmallGreenFlameTrails", 58, 30, random (0, 360), 2, random (70, 110))
@@ -399,7 +400,7 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 		TNT1 A 0 bright A_CustomMissile ("SmallGreenFlameTrails", 48, 30, random (0, 360), 2, random (70, 110))
 		TNT1 A 0 bright A_CustomMissile ("SmallGreenFlameTrails", 48, -30, random (0, 360), 2, random (70, 110))
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 58)
-		TNT1 A 0 A_CustomMissile("GreenPlasmaBall", 36, 15, 9, 11) 
+		TNT1 A 0 A_CustomMissile("GreenPlasmaBall", 36, 15, 9, 11)
 		TNT1 A 0 A_CustomMissile("GreenPlasmaBall", 36, 15, -9, 11)
 		BARO R 8 A_CustomMissile("GreenPlasmaBall", 36, 15, 0, 11)
 		TNT1 A 0 A_TakeInventory("ComingToGetTheBarrel", 1)
@@ -410,7 +411,7 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 		TNT1 A 0
 		TNT1 A 0 A_JumpIfCloser(600, "Retreat")
 		Goto Missile+5
-	
+
 	Retreat:
 		TNT1 A 0
         //TNT1 A 0 A_SpawnItemEx("FootSep", 0, 0)
@@ -420,7 +421,7 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 58)
 		BARO DD 2 A_Recoil(2)
 		TNT1 A 0 A_FaceTarget
-		
+
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 58)
 		BARO CC 2 A_Recoil(1)
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 58)
@@ -434,14 +435,14 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 58)
 		BARO AA 2 A_Recoil(1)
 		Goto Missile+5
-	
+
 	Pain.CallingTheBaronAFaggot:
 		TNT1 A 0
 		TNT1 A 0 HealThing(1)
 		TNT1 A 0 A_GiveInventory("ComingToGetTheBarrel", 1)
 		TNT1 A 0
 		Goto See2
-	
+
 	MissileBarrel:
 		BOBA A 0
 		BOBA A 1 A_Chase("","")
@@ -455,21 +456,21 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 		TNT1 A 0 A_CheckSight("WaitingToThrow")
 		BOBA E 16
 		BOBA D 8
-	
+
 	    ThrowBarrel:
 	    TNT1 A 0 A_SpawnItem("HeadshotTarget4b", 0, 58)
 	    BARO P 2 A_FaceTarget
 		TNT1 A 0 A_CustomMissile("ThrowedBarrel", 46, 15, 0, 11)
 		TNT1 A 0 A_SpawnItem("HeadshotTarget4b", 0, 58)
 		BARO Q 4 A_FaceTarget
-		
+
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 58)
-		BARO R 8 
+		BARO R 8
 		TNT1 A 0 A_TakeInventory("ComingToGetTheBarrel", 1)
 		TNT1 A 0 A_TakeInventory("HasExplosiveBarrel", 1)
 		BOBA A 0 A_ChangeFlag("NOPAIN", 0)
 		Goto See2
-	
+
 	WithBarrelLookFOrTheplayer:
 		TNT1 A 0
 		TNT1 A 0 A_ClearTarget
@@ -483,13 +484,13 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 		TNT1 A 0 A_SpawnItem("HeadshotTarget4b", 0, 58)
 		BARO H  3 A_Pain
 		Goto See2
-	
+
 	Pain.Explosive:
 		TNT1 A 0
 		TNT1 A 0 A_SpawnItemEx("MuchBlood2Green", 0, 0, 60)
 		TNT1 A 0 ThrustThingZ(0,10,0,1)
 		Goto Pain
-		
+
 	Death:
 		BXDE A  0
 		BXDE B  0 A_Scream
@@ -502,7 +503,7 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 		TNT1 VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV 2 A_CustomMissile ("Green_LiquidBlood", 20, 0, random (0, 360), 2, random (30, 110))
 		TNT1 V -1
 		Stop
-		
+
 	Death2:
 		BADD ABCD 6
 		TNT1 A 0 A_SpawnItem("DeadBaron")
@@ -521,12 +522,12 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 		BXDE EFGH 0
         TNT1 A 0
 	    Stop
-		
+
 	Raise:
     BOSS O 8
     BOSS NMLKJI 8
-    Goto See	
-	
+    Goto See
+
 	Death.Desintegrate:
 	Death.Saw:
 		TNT1 A 0 A_Scream
@@ -547,8 +548,8 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 		TNT1 A 0 A_SpawnItemEx("DeadBaronBDSSV", 0, 0, 0, 0, 0, 0, 0, SXF_TRANSFERTRANSLATION)
 		TNT1 VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV 1 A_CustomMissile ("Green_LiquidBlood", 20, 0, random (0, 360), 2, random (30, 110))
 		TNT1 V -1
-		Stop	
-	
+		Stop
+
 		TNT1 A 0 A_FaceTarget
 		TNT1 A 0 A_ChangeFLag("NOPAIN", 1)
 		TNT1 A 0 ThrustThingZ(0,30,0,1)
@@ -574,7 +575,7 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 		TNT1 A 0 A_Pain
 		BNRJ ABCD 5 A_SpawnItem("HeadshotTarget4b", 0, 58)
 		Goto Missile
-		
+
    Death.ExplosiveImpact:
         TNT1 A 0
 		TNT1 A 0 ThrustThingZ(0,35,0,1)
@@ -583,20 +584,20 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 		TNT1 AAAAAA 0 A_CustomMissile ("XDeath1Green", 62, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AAA 0 A_CustomMissile ("Muchblood2green", 62, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_Jump(255, "Death.ExplosiveImpact1", "Death.ExplosiveImpact2")
-	
-	Death.ExplosiveImpact1:	
+
+	Death.ExplosiveImpact1:
 		BOH3 A  8 A_Scream
 		BOH3 B  8 A_NoBlocking
 		BOH3 CCCCCC  8 A_CheckFloor("Land1")
 		Goto Land1
-	
+
 	Land1:
 		BOH3 D 1
 		TNT1 A 0 A_SpawnItemEx("DeadBaronBOH3D", 0, 0, 0, 0, 0, 0, 0, SXF_TRANSFERTRANSLATION)
 		TNT1 A -1
 	    Stop
-	
-	Death.ExplosiveImpact2:	
+
+	Death.ExplosiveImpact2:
 		BOH3 E  8 A_Scream
 		BOH3 F  8 A_NoBlocking
 		TNT1 A 0 A_BossDeath
@@ -642,13 +643,13 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 	Death.SSG:
 		TNT1 A 0
 		TNT1 A 0 A_BossDeath
-		TNT1 A 0 
-		TNT1 A 0 A_JumpIfCloser(300, "Death.Minigun")	
+		TNT1 A 0
+		TNT1 A 0 A_JumpIfCloser(300, "Death.Minigun")
 		Goto Death
 
 	Death.head:
 		TNT1 A 0
-		TNT1 A 0 
+		TNT1 A 0
 		TNT1 A 0 A_JumpIfInTargetInventory("HasPlasmaWeapon", 1, "Death.Plasma")
 		TNT1 AA 0 A_CustomMissile ("muchblood2green", 62, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_JumpIfInTargetInventory("HasCutingWeapon", 1, "Death.decaptate")
@@ -662,7 +663,7 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 	    TNT1 VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV 1 A_CustomMissile ("Green_LiquidBlood", 20, 0, random (0, 360), 2, random (30, 110))
 		TNT1 A -1
 		Stop
-	
+
 	Death.decaptate:
 		TNT1 AAAAA 0 A_CustomMissile ("Xdeath1Green", 62, 0, random (0, 360), 2, random (50, 130))
 		TNT1 A 0 A_SpawnItem("MuchBlood2Green", 0, 62)
@@ -711,7 +712,7 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 		TNT1 A 0 A_SpawnItem ("GreenGrowingBloodPool")
         BOSB E -1
         Stop
-		
+
 	 Death.GreenFire:
         TNT1 A 0
         TNT1 A 0 A_XScream
@@ -722,7 +723,7 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 		TNT1 AA 0 A_CustomMissile ("XDeathBurnedMeat", 32, 0, random (0, 360), 2, random (0, 160))
 	    TNT1 AA 0 A_CustomMissile ("XDeathBurnedMeat2", 32, 0, random (0, 360), 2, random (0, 160))
 	    TNT1 AA 0 A_CustomMissile ("XDeathBurnedMeat3", 32, 0, random (0, 360), 2, random (0, 160))
-		
+
 		EXPL AAAAAAAAAAAAAAAAAAAAAAAA 0 A_CustomMissile ("GreenFlameTrails", 50, 0, random (0, 360), 2, random (0, 360))
 		XBRN AAAA 2 BRIGHT A_SpawnItem("GreenFlare",0,43)
         Stop
@@ -752,7 +753,7 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 	    TNT1 A 0 A_ChangeFlag("SOLID", 0)
         TNT1 A 0 A_SpawnItem("BaronOfHell")
         Stop
-		
+
 	Death.Ice:
 	Death.Freeze:
 	Death.Frost:
@@ -761,11 +762,11 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 	TNT1 A 0 A_ChangeFlag("SHOOTABLE", 0)
 	TNT1 A 0 A_ChangeFlag("SOLID", 0)
 	TNT1 A 0 A_SpawnItem("FrozenBaronOfHell")
-	Stop	
-	
+	Stop
+
 	Death.Massacre:
 	Goto Death
-	
+
 	 Death.Stomp:
 	    TNT1 A 0 A_Scream
 		TNT1 A 0 A_NoBlocking
@@ -781,22 +782,22 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 		GIBS Z 1
 		GIBS Z -1
 		Stop
-		
+
 	Crush:
 		TNT1 A 0
 		TNT1 AAAA 0 A_SpawnItemEx ("BodyRemovalThing",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
 		TNT1 A 1 A_XScream
 		Stop
-		
+
 	 CurbstompMarine:
         TNT1 A 0 A_ChangeFlag("NOPAIN", 1)
 		KNTF A 8
 		 TNT1 AAAA 0 A_CustomMissile ("XDeath2b", 25, 0, random (0, 360), 2, random (0, 160))
 		 TNT1 AAAA 0 A_CustomMissile ("XDeath3b", 25, 0, random (0, 360), 2, random (0, 160))
-		 
+
 		KNTF BC 8 A_CustomMissile ("XDeath1", 50, 0, random (0, 360), 2, random (0, 160))
 	    EXPL A 0 Radius_Quake (2, 24, 0, 15, 0)
-		
+
 		TNT1 A 0 A_CustomMissile ("MuchBlood2", 50, 0, random (0, 360), 2, random (0, 160))
         TNT1 AA 0 A_CustomMissile ("mUCHbLOOD3", 50, 0, random (0, 360), 2, random (0, 160))
 		KNTF DDDD 2 A_CustomMissile ("Brutal_LiquidBlood3", 25, 0, random (0, 360), 2, random (0, 40))
@@ -823,45 +824,45 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 		 TNT1 A 0 A_CustomMissile ("XDeathZombieManHead", 65, 0, random (0, 360), 2, random (70, 120))
 		3HF1 F 8
 		3HF1 G 8
-		 
+
         TNT1 A 0 A_TakeInventory("ZombieManFatality",1)
         TNT1 A 0 A_ChangeFlag("NOPAIN", 0)
-		
+
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 58)
 		3HF1 H 8 A_Chase
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 58)
 		BARO E 4 A_FaceTarget
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 58)
-		BARO F 4 A_CustomMissile("ThrowedZombieMan2", 64, 0, 0, 0) 
+		BARO F 4 A_CustomMissile("ThrowedZombieMan2", 64, 0, 0, 0)
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 58)
 		BARO G 4
 		Goto See2
-		
+
 	FatalitySergeant:
         TNT1 A 0 A_ChangeFlag("NOPAIN", 1)
        3HF1 I 8
 	   TNT1 A 0 A_PlaySound("grunt/death")
 	   3HF1 I 8
-	   
+
 	   TNT1 AAAA 0 A_CustomMissile ("Guts", 30, 0, random (0, 360), 2, random (0, 160))
 	   TNT1 AAA 0 A_CustomMissile ("XDeath1", 45, 0, random (0, 360), 2, random (0, 160))
 	   TNT1 AAA 0 A_CustomMissile ("XDeath2", 45, 0, random (0, 360), 2, random (0, 160))
 	   TNT1 AAA 0 A_CustomMissile ("XDeath3", 55, 0, random (0, 360), 2, random (0, 160))
 	   TNT1 A 0 A_SpawnItem("SergeantFatalizedByBaron")
-	   
+
 	   3HF1 J 8
-	   
+
 	   3HF1 KLM 8
-		 
+
         TNT1 A 0 A_TakeInventory("SergeantFatality",1)
         TNT1 A 0 A_ChangeFlag("NOPAIN", 0)
-		
+
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 58)
 		3HF1 M 8 A_Chase
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 58)
 		BARO E 4 A_FaceTarget
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 58)
-		BARO F 4 A_CustomMissile("ThrowedSergeantPiece", 64, 0, 0, 0) 
+		BARO F 4 A_CustomMissile("ThrowedSergeantPiece", 64, 0, 0, 0)
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 58)
 		BARO G 4
         Goto See2
@@ -870,17 +871,17 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
         TNT1 A 0 A_ChangeFlag("NOPAIN", 1)
 		TNT1 A 0 A_PlaySound("demon/pain")
         3HF1 N 8
-	   
+
 	   TNT1 A 0 A_CustomMissile ("XDeathStomach", 60, 0, random (0, 360), 2, random (0, 160))
 	   TNT1 AAA 0 A_CustomMissile ("XDeath1", 45, 0, random (0, 360), 2, random (0, 160))
 	   TNT1 AAA 0 A_CustomMissile ("XDeath2", 45, 0, random (0, 360), 2, random (0, 160))
 	   TNT1 AAA 0 A_CustomMissile ("XDeath3", 55, 0, random (0, 360), 2, random (0, 160))
- 
+
 	   3HF1 OPQ 8 A_CustomMissile ("MuchBlood", 25, 0, random (0, 360), 2, random (0, 160))
-	   
+
         TNT1 A 0 A_SpawnItem ("DeadDemonHalf", 1)
 		TNT1 A 0 A_SpawnItem ("GrowingBloodPool")
-		 
+
         TNT1 A 0 A_TakeInventory("DemonFatality",1)
         TNT1 A 0 A_ChangeFlag("NOPAIN", 0)
         Goto See2
@@ -889,14 +890,14 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
         TNT1 A 0 A_ChangeFlag("NOPAIN", 1)
 		TNT1 A 0 A_PlaySound("demon/pain")
         3HF2 ABABAB 4
-	   
+
 	   TNT1 AAAAAA 0 A_SpawnItem("MuchBlood", 40)
 	   TNT1 AAA 0 A_CustomMissile ("XDeath1", 45, 0, random (0, 360), 2, random (0, 160))
 	   TNT1 AA 0 A_CustomMissile ("XDeath2", 45, 0, random (0, 360), 2, random (0, 160))
 	   TNT1 AA 0 A_CustomMissile ("XDeath3", 55, 0, random (0, 360), 2, random (0, 160))
        TNT1 AAA 0 A_CustomMissile ("Guts", 42, 0, random (0, 360), 2, random (0, 160))
 	   3HF2 CDE 8
-	   
+
 	   3HF2 F 8 A_Chase("","")
 	   3HF2 GHIJ 8
 	   TNT1 A 0 A_SpawnItem("DeadImp_BaronFatality")
@@ -941,7 +942,7 @@ States
         BOSB EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE 8 A_CustomMissile ("PlasmaSmoke", 16, 0, random (0, 180), 2, random (0, 180))
         BOSB E -1
         Stop
-		
+
 	Death:
 		 TNT1 A 0
 	     TNT1 A 0 A_NoBlocking
@@ -979,10 +980,10 @@ States
 		 TNT1 A 0 A_NoBlocking
 		 GIBS Y 1
 		 GIBS Y -1
-		Stop		}}	
+		Stop		}}
 
 Actor DeadBaronHalfDown: DeadBaron
-{States{Spawn:        BBO2 D -1   
+{States{Spawn:        BBO2 D -1
 		Stop
 
 	Death:
@@ -994,12 +995,12 @@ Actor DeadBaronHalfDown: DeadBaron
 		 TNT1 A 0 A_SpawnItem("MuchBlood2Green", 0, 25)
 		 TNT1 A 0 A_SpawnItem("MuchBlood3Green", 0, 25)
          TNT1 AA 0 A_CustomMissile ("XDeathHellKnightLeg", 5, 0, random (0, 360), 2, random (0, 160))
-		 Stop	
+		 Stop
 
 }}
 
 Actor DeadBaronHalfUp: DeadBaron
-{States{Spawn:        BTO2 D -1        
+{States{Spawn:        BTO2 D -1
 Stop
 
 		Death:
@@ -1016,7 +1017,7 @@ Stop
 		 Stop}}
 
 Actor DeadBaronNoHead: DeadBaron
-{States{Spawn:        BADH D -1        
+{States{Spawn:        BADH D -1
 Stop
 		Death:
 		 TNT1 A 0 A_CustomMissile ("XDeathBaronOfHellTorso", 2, 0, random (0, 360), 2, random (0, 160))
@@ -1035,7 +1036,7 @@ Stop
 		 Stop	}}
 
 Actor DeadBaronBOH3D : DeadBaron
-{States{Spawn:        BOH3 D -1        
+{States{Spawn:        BOH3 D -1
 Stop
 
 	Death:
@@ -1057,11 +1058,11 @@ Stop
 		 Stop	}}
 
 Actor DeadBaronBOH3H : DeadBaronBOH3D
-{States{Spawn:        BOH3 H -1        
+{States{Spawn:        BOH3 H -1
 Stop}}
 
 Actor DeadBaronBDSSV : DeadBaron
-{States{Spawn:        BDSS V -1        
+{States{Spawn:        BDSS V -1
 Stop
 	Death:
 		 TNT1 AA 0 A_CustomMissile ("XDeathHellKnightLeg", 2, 0, random (0, 360), 2, random (0, 160))
@@ -1083,7 +1084,7 @@ Stop
 }}
 
 Actor DeadBaronClassic: DeadBaron
-{States{Spawn:        KSA8 G -1        
+{States{Spawn:        KSA8 G -1
 Stop}}
 
 ACTOR XDeathHalfBOH : DeadBaron
@@ -1099,7 +1100,7 @@ ACTOR XDeathHalfBOH : DeadBaron
     +NOTELEPORT
     +DONTSPLASH
     +MOVEWITHSECTOR
-	
+
     DeathSound "misc/xdeath1"
     States
     {
@@ -1131,7 +1132,7 @@ ACTOR DyingBaron1
 	Damagefactor "Trample", 0.5
 	Damagefactor "Burn", 0.5	Damagefactor "Fire", 0.5	Damagefactor "Flames", 0.5
 	Damagefactor "GreenFire", 0.5	Damagefactor "HumanBBQ", 0.5
-	
+
 	PainChance "Head", 255	PainChance "Taunt", 255	PainChance "Extremepunches", 16
 	PainChance "Fatality", 16	PainChance "HelperMarineFatallity", 16	PainChance "Kick", 16//255
 	PainChance "LowKick", 16	PainChance "Melee", 16	PainChance "MonsterKnocked", 16
@@ -1155,7 +1156,7 @@ ACTOR DyingBaron1
 		TNT1 A 0 A_CustomMissile ("Green_LiquidBlood", 35, 0, random (0, 360), 2, random (30, 110))
 		KSA8 BC 6 A_SpawnItem("HeadshotTarget4b", 0, 58)
 		TNT1 A 0 A_CustomMissile ("Green_LiquidBlood", 35, 0, random (0, 360), 2, random (30, 110))
-		
+
 		TNT1 A 0 A_PlaySound ("PSXDPN")
 		KSA8 BC 6 A_SpawnItem("HeadshotTarget4b", 0, 58)
 		TNT1 A 0 A_CustomMissile ("Green_LiquidBlood", 35, 0, random (0, 360), 2, random (30, 110))
@@ -1187,7 +1188,7 @@ ACTOR DyingBaron1
 		KSA8 BC 6 A_SpawnItem("HeadshotTarget4b", 0, 58)
 		TNT1 A 0 A_CustomMissile ("Green_LiquidBlood", 35, 0, random (0, 360), 2, random (30, 110))
 		Goto Death
-	
+
 	Death:
 		TNT1 A 0 A_NoBlocking
 		TNT1 A 0 A_Fall
@@ -1196,7 +1197,7 @@ ACTOR DyingBaron1
 		TNT1 A 0 A_SpawnItem("DeadBaronClassic")
 		TNT1 A 0 A_SpawnItem ("GreenGrowingBloodPool")
 		Stop
-	
+
 	Death.head:
 	    TNT1 A 0 A_SpawnItem("BaronOfHellHeadExplode", 0, 62)
         TNT1 AAA 0 A_SpawnItemEx("HealthCrueltyBonus2", 0, 0, 30, frandom (-2.5, 2.5), frandom (-2.5, 2.5), 5)
@@ -1220,15 +1221,15 @@ ACTOR DyingBaron1
 		TNT1 A 0 A_NoBlocking
 	    TNT1 A 0 A_CustomMissile ("BaronXDeath", 0, 0, random (0, 360), 2, random (0, 160))
 	    Stop
-	
+
 	Death.Shotgun:
 	Death.SSG:
 	TNT1 A 0
 	TNT1 A 0 A_JumpIfCloser(200, "Death.Minigun")
 	Goto Death
-	Death.Minigun:	
+	Death.Minigun:
 	    TNT1 A 0 A_Scream
-		TNT1 A 0 
+		TNT1 A 0
         TNT1 A 0 A_NoBlocking
 		TNT1 AAAAAA 0 A_CustomMissile ("Xdeath1Green", 40, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AA 0 A_CustomMissile ("Xdeath2bGreen", 40, 0, random (0, 360), 2, random (0, 160))
@@ -1241,16 +1242,16 @@ ACTOR DyingBaron1
 		BBO2 AABCD 10
         TNT1 A 0 A_SpawnItem ("DeadBaronHalfDown", 1)
 		TNT1 A 0 A_SpawnItem ("GreenGrowingBloodPool")
-		Stop	
+		Stop
 	}
-}	
+}
 
 ACTOR BaronAttack: BaronBall
 {
 	Radius 24
 	Height 16
 	DamageType BHFT
-	Projectile 
+	Projectile
 	+RANDOMIZE
 	+FORCEXYBILLBOARD
     +THRUGHOST
@@ -1284,7 +1285,7 @@ ACTOR CallingTheBaronAFaggot: BaronBall
 	Radius 4
 	Height 4
 	DamageType CallingTheBaronAFaggot
-	Projectile 
+	Projectile
 	+RANDOMIZE
 	+FORCEXYBILLBOARD
     +THRUGHOST
@@ -1331,10 +1332,10 @@ Spawn:
 		TNT1 A 0 A_JumpIfInventory("ImpFatality3", 1, "FatalityImp")
 		TNT1 A 0 A_JumpIfInventory("DemonFatality", 1, "FatalityDemon")
 		Goto Stand
-		
+
 	Waiting:
 			BARO A 1
-			Goto Spawn	
+			Goto Spawn
 
 	Stand:
 		TNT1 A 0
@@ -1342,7 +1343,7 @@ Spawn:
 		BTS3 A 0 A_SpawnItem("HeadshotTarget20b", 0, 72)
 		BARO BB 10 A_Look
 		Loop
-		
+
 	Stand2:
 		BARO B 10 A_Look
 		Goto Stand
@@ -1352,14 +1353,14 @@ Spawn:
 		TNT1 A 0 A_JumpIfInventory("HasExplosiveBarrel", 1, "MissileBarrel")
 	    TNT1 A 0 A_SpawnItem("HeadshotTarget4b", 0, 72)
 		BARO A 1
-        BTS3 ABC 1 
+        BTS3 ABC 1
 		TNT1 A 0 A_FaceTarget
 		TNT1 A 0 A_SpawnItem("HeadshotTarget6b", 0, 72)
 		BTS3 D 4
 		BTS3 CBA 1
 		//TNT1 A 0 HealThing(200)
 		Goto See2
-	
+
 	See2:
 		TNT1 A 0
 		TNT1 A 0 A_JumpIfInventory("Curbstomp_Marine", 1, "CurbstompMarine")
@@ -1378,13 +1379,13 @@ Spawn:
         //TNT1 A 0 A_SpawnItemEx("FootSep", 0, 0)
 		TNT1 A 0 A_SpawnItem("HeadshotTarget6b", 0, 72)
 		BARO AAA 2 A_Chase
-		
+
 		TNT1 A 0 A_SpawnItem("HeadshotTarget6b", 0, 72)
 		BARO BBB 2 A_Chase
-		
+
 		TNT1 A 0 A_SpawnItem("HeadshotTarget6b", 0, 72)
 		BARO CCC 2 A_Chase
-		
+
 		TNT1 A 0 A_SpawnItem("HeadshotTarget6b", 0, 72)
 		BARO DDD 2 A_Chase
 
@@ -1392,7 +1393,7 @@ Spawn:
 		TNT1 A 0 A_JumpIfInTargetInventory("TargetIsAMastermind", 1, "CheckRetreat")
 		TNT1 A 0 A_JumpIfInTargetInventory("IsInvisible", 1, "ForgetTarget")
 		Loop
-		
+
 	SeeNeverSeen:
 		TNT1 A 0
 		BARO A 0 A_CheckSight("SEE3")
@@ -1402,7 +1403,7 @@ Spawn:
 		BARO AA 2 A_Chase
 		TNT1 A 0 A_SpawnItem("HeadshotTarget4b", 0, 72)
 		BARO AA 2 A_Chase
-		
+
 		TNT1 A 0 A_SpawnItem("HeadshotTarget4b", 0, 72)
 		BARO B 4 A_Chase
 		TNT1 A 0 A_SpawnItem("HeadshotTarget4b", 0, 72)
@@ -1414,18 +1415,18 @@ Spawn:
 		BARO CC 2 A_Chase
 		TNT1 A 0 A_SpawnItem("HeadshotTarget4b", 0, 72)
 		BARO DD 2 A_Chase
-		
+
 		TNT1 A 0 A_SpawnItem("HeadshotTarget4b", 0, 72)
 		BARO DD 2 A_Chase
 		TNT1 A 0 A_JumpIfInTargetInventory("TargetIsACyberdemon", 1, "CheckRetreat")
 		TNT1 A 0 A_JumpIfInTargetInventory("TargetIsAMastermind", 1, "CheckRetreat")
 		TNT1 A 0 A_JumpIfInTargetInventory("IsInvisible", 1, "ForgetTarget")
-		Loop	
+		Loop
 	See3:
         //TNT1 A 0 A_SpawnItemEx("FootSep", 0, 0)
 		BARO AABBCCDD 3 A_Chase
 		Goto See4
-		
+
 	Idle:
 	LookingForPlayer:
 	    TNT1 A 0 A_GiveInventory("SKImp", 1)
@@ -1449,22 +1450,22 @@ Spawn:
 		BARO B 10 A_Look
         TNT1 A 0 A_SpawnItem ("HeadshotTarget10b", 0, 72)
 		BARO B 10 A_Look
-		
+
 		BARO A 0 A_Wander
 		BARO AA 2 A_Look
 		TNT1 A 0 A_Recoil(-2)
 		TNT1 A 0 A_SpawnItem("HeadshotTarget6b", 0, 72)
-		
+
 		BARO B 0 A_Wander
 		BARO BB 2 A_Look
 		TNT1 A 0 A_Recoil(-2)
 		TNT1 A 0 A_SpawnItem("HeadshotTarget6b", 0, 72)
-		
+
 		BARO C 0 A_Wander
 		BARO CC 2 A_Look
 		TNT1 A 0 A_Recoil(-2)
 		TNT1 A 0 A_SpawnItem("HeadshotTarget6b", 0, 72)
-		
+
 		BARO D 0 A_Wander
 		BARO DD 2 A_Look
 		TNT1 A 0 A_Recoil(-2)
@@ -1476,17 +1477,17 @@ Spawn:
 		BARO AA 2 A_Look
 		TNT1 A 0 A_Recoil(-2)
 		TNT1 A 0 A_SpawnItem("HeadshotTarget6b", 0, 72)
-		
+
 		BARO B 0 A_Wander
 		BARO BB 2 A_Look
 		TNT1 A 0 A_Recoil(-2)
 		TNT1 A 0 A_SpawnItem("HeadshotTarget6b", 0, 72)
-		
+
 		BARO C 0 A_Wander
 		BARO CC 2 A_Look
 		TNT1 A 0 A_Recoil(-2)
 		TNT1 A 0 A_SpawnItem("HeadshotTarget6b", 0, 72)
-		
+
 		BARO D 0 A_Wander
 		BARO DD 2 A_Look
 		TNT1 A 0 A_Recoil(-2)
@@ -1510,10 +1511,10 @@ Spawn:
 		TNT1 A 0 HealThing(200)
 		TNT1 A 0 A_Jump(96, "SpecialAttack")
 		Goto See2
-	
+
 	Melee:
 	    TNT1 A 0
-		
+
 	    TNT1 A 0 A_JumpIfInTargetInventory("TargetIsACyberdemon", 1, "CheckRetreat")
 		TNT1 A 0 A_JumpIfInTargetInventory("TargetIsAMastermind", 1, "CheckRetreat")
 		TNT1 A 0 A_FaceTarget
@@ -1521,7 +1522,7 @@ Spawn:
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 72)
 		BARO E 1
 		TNT1 A 0 A_JumpIfInventory("HasExplosiveBarrel", 1, "MissileBarrel")
-		
+
         BARO E 6
         TNT1 A 0 A_PlaySound("weapons/gswing")
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 72)
@@ -1529,12 +1530,12 @@ Spawn:
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 72)
 		BARO G 6 A_CustomMissile("BaronAttack",10,0,0,0)
 		TNT1 A 0 A_JumpIfInventory("Curbstomp_Marine", 1, "CurbstompMarine")
-		TNT1 A 0 A_JumpIfInventory("ZombiemanFatality", 1, "FatalityZombieman")		
+		TNT1 A 0 A_JumpIfInventory("ZombiemanFatality", 1, "FatalityZombieman")
 		Goto See2
-		
+
 	Melee2:
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 72)
-		
+
 		BARO E 6 A_FaceTarget
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 72)
 		BARO F 6 A_FaceTarget
@@ -1546,10 +1547,10 @@ Spawn:
 		TNT1 A 0 A_JumpIfInventory("DemonFatality", 1, "FatalityDemon")
 		TNT1 A 0 A_JumpIfInventory("ImpFatality3", 1, "FatalityImp")
 		Goto See2
-	
+
     Missile:
 		BARO A 1
-		
+
 		TNT1 A 0 A_TakeInventory("EnemyMemory", 30)
 		TNT1 A 0 A_JumpIfInTargetInventory("TargetIsACyberdemon", 1, "CheckRetreat")
 		TNT1 A 0 A_JumpIfInTargetInventory("TargetIsAMastermind", 1, "CheckRetreat")
@@ -1558,15 +1559,15 @@ Spawn:
 		TNT1 A 0 A_JumpIfInventory("Curbstomp_Marine", 1, "CurbstompMarine")
 		TNT1 A 0 A_JumpIfInventory("ZombiemanFatality", 1, "FatalityZombieman")
 		TNT1 A 0 A_JumpIfInTargetInventory ("TypeZombieman", 1, "See2")
-		TNT1 A 0 A_JumpIfInTargetInventory ("TypeSergeant", 1, "See2") 
-        
+		TNT1 A 0 A_JumpIfInTargetInventory ("TypeSergeant", 1, "See2")
+
 		//TNT1 A 0 A_JumpIfInTargetInventory("IsPlayer", 0, 5)
 		//TNT1 A 0 A_TakeInventory("CantFire", 1)
-		//TNT1 A 0 A_CustomMissile("MonsterTargetCheck", 34, 0, 0, 0) 
-		//TNT1 A 0 A_CustomMissile("MonsterTargetCheckFaster", 34, 0, 0, 0)  
+		//TNT1 A 0 A_CustomMissile("MonsterTargetCheck", 34, 0, 0, 0)
+		//TNT1 A 0 A_CustomMissile("MonsterTargetCheckFaster", 34, 0, 0, 0)
 		BARO e 3 A_FaceTarget
 		//TNT1 A 0 A_JumpIfInventory("CantFire",1, "See4")
-		
+
 		TNT1 A 0 A_Jump (64, "SpecialAttack")
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 72)
 		BARO E 2 A_FaceTarget
@@ -1584,7 +1585,7 @@ Spawn:
 		TNT1 A 0 bright A_CustomMissile ("SmallGreenFlameTrails", 78, 40, random (0, 360), 2, random (70, 110))
 		TNT1 A 0 A_CustomMissile ("BallGettingReadyGreen", 79, 40, random (0, 140), 2, random (0, 160))
 		BARO E 2 A_FaceTarget
-		
+
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 72)
 		BARO F 3 A_FaceTarget
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 72)
@@ -1596,7 +1597,7 @@ Spawn:
 
     SpecialAttack:
 	    TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 72)
-		
+
 		BARO R 3 A_FaceTarget
 	    TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 72)
 		BARO Q 6 A_FaceTarget
@@ -1624,7 +1625,7 @@ Spawn:
 		TNT1 A 0 bright A_CustomMissile ("SmallGreenFlameTrails", 78, -40, random (0, 360), 2, random (70, 110))
 		TNT1 A 0 A_CustomMissile ("BallGettingReadyGreen", 79, -40, random (0, 140), 2, random (0, 160))
 		BARO P 2 A_FaceTarget
-		
+
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 72)
 		BARO Q 4 A_FaceTarget
 		TNT1 A 0 bright A_CustomMissile ("SmallGreenFlameTrails", 58, 30, random (0, 360), 2, random (70, 110))
@@ -1633,7 +1634,7 @@ Spawn:
 		TNT1 A 0 bright A_CustomMissile ("SmallGreenFlameTrails", 48, 30, random (0, 360), 2, random (70, 110))
 		TNT1 A 0 bright A_CustomMissile ("SmallGreenFlameTrails", 48, -30, random (0, 360), 2, random (70, 110))
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 72)
-		TNT1 A 0 A_CustomMissile("GreenPlasmaBall", 36, 15, 9, 11) 
+		TNT1 A 0 A_CustomMissile("GreenPlasmaBall", 36, 15, 9, 11)
 		TNT1 A 0 A_CustomMissile("GreenPlasmaBall", 36, 15, -9, 11)
 		BARO R 8 A_CustomMissile("GreenPlasmaBall", 36, 15, 0, 11)
 		TNT1 A 0 A_TakeInventory("ComingToGetTheBarrel", 1)
@@ -1644,7 +1645,7 @@ Spawn:
 		TNT1 A 0
 		TNT1 A 0 A_JumpIfCloser(600, "Retreat")
 		Goto Missile+5
-	
+
 	Retreat:
 		TNT1 A 0
         //TNT1 A 0 A_SpawnItemEx("FootSep", 0, 0)
@@ -1654,7 +1655,7 @@ Spawn:
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 72)
 		BARO DD 2 A_Recoil(2)
 		TNT1 A 0 A_FaceTarget
-		
+
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 72)
 		BARO CC 2 A_Recoil(1)
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 72)
@@ -1668,14 +1669,14 @@ Spawn:
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 72)
 		BARO AA 2 A_Recoil(1)
 		Goto Missile+5
-	
+
 	Pain.CallingTheBaronAFaggot:
 		TNT1 A 0
 		TNT1 A 0 HealThing(1)
 		TNT1 A 0 A_GiveInventory("ComingToGetTheBarrel", 1)
 		TNT1 A 0
 		Goto See2
-	
+
 	MissileBarrel:
 		BOBA A 0
 		BOBA A 1 A_Chase("","")
@@ -1689,21 +1690,21 @@ Spawn:
 		TNT1 A 0 A_CheckSight("WaitingToThrow")
 		BOBA E 16
 		BOBA D 8
-	
+
 	    ThrowBarrel:
 	    TNT1 A 0 A_SpawnItem("HeadshotTarget4b", 0, 72)
 	    BARO P 2 A_FaceTarget
 		TNT1 A 0 A_CustomMissile("ThrowedBarrel", 46, 15, 0, 11)
 		TNT1 A 0 A_SpawnItem("HeadshotTarget4b", 0, 72)
 		BARO Q 4 A_FaceTarget
-		
+
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 72)
-		BARO R 8 
+		BARO R 8
 		TNT1 A 0 A_TakeInventory("ComingToGetTheBarrel", 1)
 		TNT1 A 0 A_TakeInventory("HasExplosiveBarrel", 1)
 		BOBA A 0 A_ChangeFlag("NOPAIN", 0)
 		Goto See2
-	
+
 	WithBarrelLookFOrTheplayer:
 		TNT1 A 0
 		TNT1 A 0 A_ClearTarget
@@ -1717,13 +1718,13 @@ Spawn:
 		TNT1 A 0 A_SpawnItem("HeadshotTarget4b", 0, 72)
 		BARO H  3 A_Pain
 		Goto See2
-	
+
 	Pain.Explosive:
 		TNT1 A 0
 		TNT1 A 0 A_SpawnItemEx("MuchBlood2Green", 0, 0, 60)
 		TNT1 A 0 ThrustThingZ(0,10,0,1)
 		Goto Pain
-		
+
 	Death:
 		BXDE A  0
 		BXDE B  0 A_Scream
@@ -1736,7 +1737,7 @@ Spawn:
 		TNT1 VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV 2 A_CustomMissile ("Green_LiquidBlood", 20, 0, random (0, 360), 2, random (30, 110))
 		TNT1 V -1
 		Stop
-		
+
 	Death2:
 		BADD ABCD 6
 		TNT1 A 0 A_SpawnItem("DeadBaron")
@@ -1755,12 +1756,12 @@ Spawn:
 		BXDE EFGH 0
         TNT1 A 0
 	    Stop
-		
+
 	Raise:
     BOSS O 8
     BOSS NMLKJI 8
-    Goto See	
-	
+    Goto See
+
 	Death.Desintegrate:
 	Death.Saw:
 		TNT1 A 0 A_Scream
@@ -1781,8 +1782,8 @@ Spawn:
 		TNT1 A 0 A_SpawnItemEx("DeadBaronBDSSV", 0, 0, 0, 0, 0, 0, 0, SXF_TRANSFERTRANSLATION)
 		TNT1 VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV 1 A_CustomMissile ("Green_LiquidBlood", 20, 0, random (0, 360), 2, random (30, 110))
 		TNT1 V -1
-		Stop	
-	
+		Stop
+
 		TNT1 A 0 A_FaceTarget
 		TNT1 A 0 A_ChangeFLag("NOPAIN", 1)
 		TNT1 A 0 ThrustThingZ(0,30,0,1)
@@ -1808,7 +1809,7 @@ Spawn:
 		TNT1 A 0 A_Pain
 		BNRJ ABCD 5 A_SpawnItem("HeadshotTarget4b", 0, 72)
 		Goto Missile
-		
+
    Death.ExplosiveImpact:
         TNT1 A 0
 		TNT1 A 0 ThrustThingZ(0,35,0,1)
@@ -1817,20 +1818,20 @@ Spawn:
 		TNT1 AAAAAA 0 A_CustomMissile ("XDeath1Green", 62, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AAA 0 A_CustomMissile ("Muchblood2green", 62, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_Jump(255, "Death.ExplosiveImpact1", "Death.ExplosiveImpact2")
-	
-	Death.ExplosiveImpact1:	
+
+	Death.ExplosiveImpact1:
 		BOH3 A  8 A_Scream
 		BOH3 B  8 A_NoBlocking
 		BOH3 CCCCCC  8 A_CheckFloor("Land1")
 		Goto Land1
-	
+
 	Land1:
 		BOH3 D 1
 		TNT1 A 0 A_SpawnItemEx("DeadBaronBOH3D", 0, 0, 0, 0, 0, 0, 0, SXF_TRANSFERTRANSLATION)
 		TNT1 A -1
 	    Stop
-	
-	Death.ExplosiveImpact2:	
+
+	Death.ExplosiveImpact2:
 		BOH3 E  8 A_Scream
 		BOH3 F  8 A_NoBlocking
 		TNT1 A 0 A_BossDeath
@@ -1876,13 +1877,13 @@ Spawn:
 	Death.SSG:
 		TNT1 A 0
 		TNT1 A 0 A_BossDeath
-		TNT1 A 0 
-		TNT1 A 0 A_JumpIfCloser(300, "Death.Minigun")	
+		TNT1 A 0
+		TNT1 A 0 A_JumpIfCloser(300, "Death.Minigun")
 		Goto Death
 
 	Death.head:
 		TNT1 A 0
-		TNT1 A 0 
+		TNT1 A 0
 		TNT1 A 0 A_JumpIfInTargetInventory("HasPlasmaWeapon", 1, "Death.Plasma")
 		TNT1 AA 0 A_CustomMissile ("muchblood2green", 62, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_JumpIfInTargetInventory("HasCutingWeapon", 1, "Death.decaptate")
@@ -1896,7 +1897,7 @@ Spawn:
 	    TNT1 VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV 1 A_CustomMissile ("Green_LiquidBlood", 20, 0, random (0, 360), 2, random (30, 110))
 		TNT1 A -1
 		Stop
-	
+
 	Death.decaptate:
 		TNT1 AAAAA 0 A_CustomMissile ("Xdeath1Green", 62, 0, random (0, 360), 2, random (50, 130))
 		TNT1 A 0 A_SpawnItem("MuchBlood2Green", 0, 62)
@@ -1945,7 +1946,7 @@ Spawn:
 		TNT1 A 0 A_SpawnItem ("GreenGrowingBloodPool")
         BOSB E -1
         Stop
-		
+
 	 Death.GreenFire:
         TNT1 A 0
         TNT1 A 0 A_XScream
@@ -1956,7 +1957,7 @@ Spawn:
 		TNT1 AA 0 A_CustomMissile ("XDeathBurnedMeat", 32, 0, random (0, 360), 2, random (0, 160))
 	    TNT1 AA 0 A_CustomMissile ("XDeathBurnedMeat2", 32, 0, random (0, 360), 2, random (0, 160))
 	    TNT1 AA 0 A_CustomMissile ("XDeathBurnedMeat3", 32, 0, random (0, 360), 2, random (0, 160))
-		
+
 		EXPL AAAAAAAAAAAAAAAAAAAAAAAA 0 A_CustomMissile ("GreenFlameTrails", 50, 0, random (0, 360), 2, random (0, 360))
 		XBRN AAAA 2 BRIGHT A_SpawnItem("GreenFlare",0,43)
         Stop
@@ -1986,7 +1987,7 @@ Spawn:
 	    TNT1 A 0 A_ChangeFlag("SOLID", 0)
         TNT1 A 0 A_SpawnItem("BaronOfHell")
         Stop
-		
+
 	Death.Ice:
 	Death.Freeze:
 	Death.Frost:
@@ -1995,11 +1996,11 @@ Spawn:
 	TNT1 A 0 A_ChangeFlag("SHOOTABLE", 0)
 	TNT1 A 0 A_ChangeFlag("SOLID", 0)
 	TNT1 A 0 A_SpawnItem("FrozenBaronOfHell")
-	Stop	
-	
+	Stop
+
 	Death.Massacre:
 	Goto Death
-	
+
 	 Death.Stomp:
 	    TNT1 A 0 A_Scream
 		TNT1 A 0 A_NoBlocking
@@ -2015,22 +2016,22 @@ Spawn:
 		GIBS Z 1
 		GIBS Z -1
 		Stop
-		
+
 	Crush:
 		TNT1 A 0
 		TNT1 AAAA 0 A_SpawnItemEx ("BodyRemovalThing",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
 		TNT1 A 1 A_XScream
 		Stop
-		
+
 	 CurbstompMarine:
         TNT1 A 0 A_ChangeFlag("NOPAIN", 1)
 		KNTF A 15
 		 TNT1 AAAA 0 A_CustomMissile ("XDeath2b", 25, 0, random (0, 360), 2, random (0, 160))
 		 TNT1 AAAA 0 A_CustomMissile ("XDeath3b", 25, 0, random (0, 360), 2, random (0, 160))
-		 
+
 		KNTF BCD 8 A_CustomMissile ("XDeath1", 50, 0, random (0, 360), 2, random (0, 160))
 	    EXPL A 0 Radius_Quake (2, 24, 0, 15, 0)
-		
+
 		TNT1 A 0 A_CustomMissile ("MuchBlood2", 50, 0, random (0, 360), 2, random (0, 160))
         TNT1 AA 0 A_CustomMissile ("mUCHbLOOD3", 50, 0, random (0, 360), 2, random (0, 160))
 		KNTF DDDDDDDDDDDDDDDDDDDDDD 3 A_CustomMissile ("Brutal_LiquidBlood3", 25, 0, random (0, 360), 2, random (0, 40))
@@ -2057,45 +2058,45 @@ Spawn:
 		 TNT1 A 0 A_CustomMissile ("XDeathZombieManHead", 65, 0, random (0, 360), 2, random (70, 120))
 		3HF1 F 30
 		3HF1 G 10
-		 
+
         TNT1 A 0 A_TakeInventory("ZombieManFatality",1)
         TNT1 A 0 A_ChangeFlag("NOPAIN", 0)
-		
+
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 72)
 		3HF1 H 8 A_Chase
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 72)
 		BARO E 8 A_FaceTarget
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 72)
-		BARO F 8 A_CustomMissile("ThrowedZombieMan2", 64, 0, 0, 0) 
+		BARO F 8 A_CustomMissile("ThrowedZombieMan2", 64, 0, 0, 0)
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 72)
 		BARO G 8
 		Goto See2
-		
+
 	FatalitySergeant:
         TNT1 A 0 A_ChangeFlag("NOPAIN", 1)
        3HF1 I 15
 	   TNT1 A 0 A_PlaySound("grunt/death")
 	   3HF1 I 5
-	   
+
 	   TNT1 AAAA 0 A_CustomMissile ("GreenGuts", 30, 0, random (0, 360), 2, random (0, 160))
 	   TNT1 AAA 0 A_CustomMissile ("XDeath1", 45, 0, random (0, 360), 2, random (0, 160))
 	   TNT1 AAA 0 A_CustomMissile ("XDeath2", 45, 0, random (0, 360), 2, random (0, 160))
 	   TNT1 AAA 0 A_CustomMissile ("XDeath3", 55, 0, random (0, 360), 2, random (0, 160))
 	   TNT1 A 0 A_SpawnItem("SergeantFatalizedByBaron")
-	   
+
 	   3HF1 J 10
-	   
+
 	   3HF1 KLM 15
-		 
+
         TNT1 A 0 A_TakeInventory("SergeantFatality",1)
         TNT1 A 0 A_ChangeFlag("NOPAIN", 0)
-		
+
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 72)
 		3HF1 M 1 A_Chase
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 72)
 		BARO E 8 A_FaceTarget
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 72)
-		BARO F 8 A_CustomMissile("ThrowedSergeantPiece", 64, 0, 0, 0) 
+		BARO F 8 A_CustomMissile("ThrowedSergeantPiece", 64, 0, 0, 0)
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 72)
 		BARO G 8
         Goto See2
@@ -2104,17 +2105,17 @@ Spawn:
         TNT1 A 0 A_ChangeFlag("NOPAIN", 1)
 		TNT1 A 0 A_PlaySound("demon/pain")
         3HF1 N 20
-	   
+
 	   TNT1 A 0 A_CustomMissile ("XDeathStomach", 60, 0, random (0, 360), 2, random (0, 160))
 	   TNT1 AAA 0 A_CustomMissile ("XDeath1", 45, 0, random (0, 360), 2, random (0, 160))
 	   TNT1 AAA 0 A_CustomMissile ("XDeath2", 45, 0, random (0, 360), 2, random (0, 160))
 	   TNT1 AAA 0 A_CustomMissile ("XDeath3", 55, 0, random (0, 360), 2, random (0, 160))
- 
+
 	   3HF1 OPQQQ 10 A_CustomMissile ("MuchBlood", 25, 0, random (0, 360), 2, random (0, 160))
-	   
+
         TNT1 A 0 A_SpawnItem ("DeadDemonHalf", 1)
 		TNT1 A 0 A_SpawnItem ("GreenGrowingBloodPool")
-		 
+
         TNT1 A 0 A_TakeInventory("DemonFatality",1)
         TNT1 A 0 A_ChangeFlag("NOPAIN", 0)
         Goto See2
@@ -2123,14 +2124,14 @@ Spawn:
         TNT1 A 0 A_ChangeFlag("SHOOTABLE", 0)
 		TNT1 A 0 A_PlaySound("demon/pain")
         3HF2 ABABAB 4
-	   
+
 	   TNT1 AAAAAA 0 A_SpawnItem("MuchBlood", 40)
 	   TNT1 AAA 0 A_CustomMissile ("XDeath1", 45, 0, random (0, 360), 2, random (0, 160))
 	   TNT1 AA 0 A_CustomMissile ("XDeath2", 45, 0, random (0, 360), 2, random (0, 160))
 	   TNT1 AA 0 A_CustomMissile ("XDeath3", 55, 0, random (0, 360), 2, random (0, 160))
        TNT1 AAA 0 A_CustomMissile ("GreenGuts", 42, 0, random (0, 360), 2, random (0, 160))
 	   3HF2 CDE 6
-	   
+
 	   3HF2 F 1 A_Chase("","")
 	   3HF2 FFF 15
 	   3HF2 GGHHIJ 3
@@ -2157,10 +2158,10 @@ Spawn:
 		TNT1 A 0 A_JumpIfInventory("ImpFatality3", 1, "FatalityImp")
 		TNT1 A 0 A_JumpIfInventory("DemonFatality", 1, "FatalityDemon")
 		Goto Stand
-			
+
 Waiting:
 			BARO A 1
 			Goto Spawn
-			
+
 		}
 }

--- a/ExpansionChangelog.txt
+++ b/ExpansionChangelog.txt
@@ -5,7 +5,8 @@
 //
 //	Development v0.3.2
 //
-//	
+//	Explosives.txt:					Removed +THRUGHOST from Cyberballs (was going through headshot actors)
+//	Tracers.txt:					Removed +THRUGHOST from tracers so they will hit headshot actors
 //
 //	Development v0.3.1
 //

--- a/Explosives.txt
+++ b/Explosives.txt
@@ -25,7 +25,7 @@ ACTOR Rocket2
 	States
 	{
 	Spawn:
-	
+
 		MISL A 0
 		TNT1 A 0 A_PlaySound("DSRLAUN")
 		TNT1 A 0 BRIGHT A_CustomMissile("RocketBackblast", 0, 0, angle-180, CMF_ABSOLUTEANGLE)
@@ -35,22 +35,22 @@ ACTOR Rocket2
 		TNT1 A 0 BRIGHT A_CustomMissile("BackblastFlames2", 0, 0, angle-180, CMF_ABSOLUTEANGLE)
 		TNT1 A 0 BRIGHT A_CustomMissile("BackblastFlames3", 0, 0, angle-180, CMF_ABSOLUTEANGLE)
 		TNT1 A 0 BRIGHT A_CustomMissile("BackblastFlames4", 0, 0, angle-180, CMF_ABSOLUTEANGLE)
-		
+
 	Live:
-	    MISL A 1 Bright 
+	    MISL A 1 Bright
 		TNT1 A 0 A_JumpIf(waterlevel > 1, "SpawnUnderwater")
 		TNT1 A 0 A_SpawnItem("RocketFlare",-20,0)
 		TNT1 A 0 A_SpawnItem ("OldschoolRocketSmokeTrail2")
 		TNT1 A 0 A_CustomMissile ("OldschoolRocketSmokeTrail2", 2, 0, random (160, 210), 2, random (-30, 30))
 		Loop
-	
+
 	SpawnUnderwater:
 	    TNT1 A 0 A_ChangeFlag("NOGRAVITY", 0)
 		TNT1 A 0 A_SpawnItem("RocketFlare",-20,0)
 	    TNT1 A 0 A_CustomMissile ("BUBULZ", 0, 0, random (0, 360), 2, random (0, 180))
-		MISL A 1 Bright 
+		MISL A 1 Bright
 	    Goto Live
-	
+
 	Death:
         EXPL A 0 Radius_Quake (3, 8, 0, 15, 0)//(intensity, duration, damrad, tremrad, tid)
 		TNT1 A 0 A_CustomMissile("ExplosionSplashSpawner")
@@ -95,7 +95,7 @@ Actor RocketBackblast: FastProjectile
 			//TNT1 A 0 A_CustomMissile("ExplosionSmokeHD", 2, 0, random(0, 360), 2, random(0, 90))
 			EXPL GHI 1 //A_CustomMissile ("BackblastFlames", 0, 0, random (0, 360), 2, random (0, 360))
 			Stop
-			
+
 		Death:
 			TNT1 A 0
 			TNT1 A 0 ACS_NamedExecuteAlways("CheckRocketBackblast")
@@ -120,12 +120,12 @@ Actor RocketBackblast2: RocketBackblast
 	{
 		Spawn:
 			TNT1 A 0
-			
+
 			TNT1 A 2
 			TNT1 A 0 A_CustomMissile("ExplosionSmokeHD", 2, 0, random(0, 360), 2, random(0, 90))
 			TNT1 GHI 1 //A_CustomMissile ("BackblastFlames", 0, 0, random (0, 360), 2, random (0, 360))
 			Stop
-			
+
 		Death:
 			TNT1 A 0
 			TNT1 A 0 ACS_NamedExecuteAlways("CheckRocketBackblast")
@@ -144,7 +144,7 @@ Actor RocketBackblast3: RocketBackblast2
 	Damagetype "Shrapnel"
 	States
 	{
-		
+
 		Death:
 			TNT1 A 3
 			TNT1 A 0 A_Explode(32, 64, 0, 0, 64)
@@ -160,7 +160,7 @@ Actor RocketBackblastRealism: RocketBackblast
 	damagetype ExplosiveImpact
 	States
 	{
-		
+
 		Death:
 			TNT1 A 0
 			TNT1 A 0 ACS_NamedExecuteAlways("CheckRocketBackblast")
@@ -184,7 +184,7 @@ States
 		TNT1 A 0
 		TNT1 A 2
 		Stop
-		
+
 Death:
 	TNT1 A 0
 	TNT1 A 0 ACS_NamedExecuteAlways("CheckRocketBackblast")
@@ -243,7 +243,7 @@ States    {
 	TNT1 A 3
 	TNT1 A 0 A_Explode(100,150)
         Stop}}
-		
+
 actor LiquidExplosionEffectSpawner
 {
 +NOBLOCKMAP
@@ -256,7 +256,7 @@ States    {
 	TNT1 A 1
 	TNT1 A 0 A_Explode(3,9)
         Stop}}
-		
+
 actor BarrelExplosion: RocketExplosion
 {
 +FORCERADIUSDMG
@@ -281,7 +281,7 @@ States    {
 	TNT1 A 0 A_SpawnItem("WhiteShockwaveBig")
 	TNT1 A 3
 TNT1 A 0 A_Explode(200,300)
-        Stop}}		
+        Stop}}
 
 actor BarrelExplosionAnnouncer: RocketExplosion
 {
@@ -296,8 +296,8 @@ States    {
 	TNT1 A 0 A_SpawnItem("WhiteShockwaveBig")
 	TNT1 A 3
 TNT1 A 0 A_Explode(3,220)
-        Stop}}		
-		
+        Stop}}
+
 actor GrenadeExplosion: RocketExplosion
 {
 States    {
@@ -306,7 +306,7 @@ States    {
 	TNT1 A 3
 TNT1 A 0 A_Explode(100,300)
 TNT1 A 0 A_SpawnItem("WhiteShockwaveBig")
-        Stop}}	
+        Stop}}
 
 actor BFGSprayExplosion: RocketExplosion
 {
@@ -317,7 +317,7 @@ States    {
 	TNT1 A 0
 	TNT1 A 1
 TNT1 A 0 A_Explode(40,1)
-        Stop}}	
+        Stop}}
 
 ACTOR CyberRocket: Rocket2
 {
@@ -360,29 +360,29 @@ ACTOR GrenadeMissile
 		GBPJ EEEFFFGGGHHH 1 A_CustomMissile ("RocketSmokeTrail52", 2, 0, random (70, 110), 2, random (0, 360))
 		TNT1 A 0 A_JumpIfInventory("STGrenadeTimer", 6, "Explode")
 		Loop
-	
+
 	SpawnUnderwater:
 		TNT1 A 0 A_GiveInventory("STGrenadeTimer", 1)
 		GBPJ ABCD 3
 		TNT1 A 0 A_JumpIfInventory("STGrenadeTimer", 6, "Explode")
 		TNT1 A 0 A_GiveInventory("STGrenadeTimer", 1)
-		GBPJ EFGH 3	
+		GBPJ EFGH 3
 		TNT1 A 0 A_JumpIfInventory("STGrenadeTimer", 6, "Explode")
 	    Goto Spawn
-	
+
 	Death:
 	    TNT1 A 0
 		TNT1 A 0 A_JumpIfInventory("STGrenadeTimer", 6, "Explode")
 		GBPJ AAAA 3 A_CustomMissile ("RocketSmokeTrail52", 2, 0, random (70, 110), 2, random (0, 360))
 		TNT1 A 0 A_GiveInventory("STGrenadeTimer", 1)
 		Loop
-		
+
 	XDeath:
 	TNT1 A 0 A_Recoil(1)
 	TNT1 A 0 A_SetAngle(random (90,-90) + angle)
 	GBPJ C 1 ThrustThingZ(0,20,0,1)
 	Goto Spawn
-	
+
 	Explode:
 	Death.Slime:
 	Death.Fire:
@@ -408,7 +408,7 @@ ACTOR GrenadeMissile
         TNT1 AAAAAAAAAA 0 A_CustomMissile ("BDExplosionparticlesBig", 0, 0, random (0, 360), 2, random (0, 360))
 		TNT1 AAAAA 0 A_CustomMissile ("BDExplosionparticles2", 0, 0, random (0, 360), 2, random (0, 90))
 		TNT1 AAAA 0 A_CustomMissile ("MediumExplosionFlames", 0, 0, random (0, 360), 2, random (0, 360))//TNT1 AAAAAAAAAAAAA 3 A_CustomMissile ("HeavyExplosionSmoke", 2, 0, random (0, 360), 2, random (0, 360))
-		Stop	
+		Stop
 	}
 }
 
@@ -428,16 +428,16 @@ ACTOR ShortGrenade: GrenadeMissile
 	    TNT1 A 0 A_JumpIf(waterlevel > 1, "SpawnUnderwater")
 		GBPJ AAAAAAAAABBBBBBBCCCCCDDDDDEEEEEFFFFFGGGGGHHHHH 1 A_CustomMissile ("RocketSmokeTrail52", 2, 0, random (70, 110), 2, random (0, 360))
 		Loop
-	
+
 	SpawnUnderwater:
 		TNT1 A 0 A_GiveInventory("STGrenadeTimer", 1)
 		GBPJ ABCD 3
 		TNT1 A 0 A_JumpIfInventory("STGrenadeTimer", 1, "Explode")
 		TNT1 A 0 A_GiveInventory("STGrenadeTimer", 1)
-		GBPJ EFGH 3	
+		GBPJ EFGH 3
 		TNT1 A 0 A_JumpIfInventory("STGrenadeTimer", 1, "Explode")
 	    Goto Spawn
-	
+
 	Death:
 	XDeath:
 	TNT1 A 1
@@ -458,13 +458,13 @@ ACTOR GrenadeMissileBreaksGlass: ShortGrenade
 	    TNT1 A 1
 		TNT1 A -1
 		Stop
-	
+
 	Death:
 	XDeath:
 	Melee:
 	    TNT1 A 0
 		Stop
-		
+
 	}
 }
 
@@ -512,7 +512,7 @@ Actor DragonBreath
 	Projectile
 	+RANDOMIZE
 +FORCEXYBILLBOARD
--BLOODSPLATTER 
+-BLOODSPLATTER
 +BLOODLESSIMPACT
 damage 0
 radius 1
@@ -555,7 +555,6 @@ ACTOR CyberBalls: Rocket2
 	Renderstyle Add
     -NOGRAVITY
 	+EXTREMEDEATH
-	+THRUGHOST
 	Species "Cyberdemon"
 	Scale 1.7
     SeeSound "DSCANFIR"
@@ -567,21 +566,21 @@ ACTOR CyberBalls: Rocket2
 	Spawn:
 	    TNT1 A 0
 		TNT1 A 0 ACS_NamedExecuteAlways("BDCheckJanitor", 0, 0, 0, 0)//Check Effects
-		
-	Spawn1:	
+
+	Spawn1:
 		TNT1 A 0 A_JumpIf(waterlevel > 1, "SpawnUnderwater")
-	    WYVB A 1 Bright A_SpawnItem("RedFlareSmall22",0,0) 
+	    WYVB A 1 Bright A_SpawnItem("RedFlareSmall22",0,0)
 		TNT1 A 0 A_CustomMissile ("OldschoolRocketSmokeTrail2", 2, 0, random (160, 210), 2, random (-30, 30))
 		TNT1 A 0 A_JumpIfInventory("lowgraphicsmode", 1, "SpawnCheap")
 		Loop
-		
+
 	SpawnCheap:
 	    TNT1 A 0
-	    WYVB A 1 Bright A_SpawnItem("RedFlareSmall22",0,0) 
-		Loop	
+	    WYVB A 1 Bright A_SpawnItem("RedFlareSmall22",0,0)
+		Loop
 
 SpawnUnderwater:
-	    WYVB A 1 Bright A_SpawnItem("YellowFlareSmall",0,0) 
+	    WYVB A 1 Bright A_SpawnItem("YellowFlareSmall",0,0)
         TNT1 A 0 A_CustomMissile ("BUBULZ", 0, 0, random (0, 360), 2, random (0, 180))
 		Goto Spawn1
 	}
@@ -724,7 +723,7 @@ Species "None"
 	States
 	{
 	Spawn:
-	
+
 		TNT1 A 0
 		TNT1 A 0 A_PlaySound("DSRLAUN")
 		TNT1 A 0 BRIGHT A_CustomMissile("RocketBackblast", 0, 0, 180, 2, 0+pitch)
@@ -735,13 +734,13 @@ Species "None"
 		TNT1 A 0 A_CustomMissile ("ExplosionSmoke", 2, 0, random (160, 210), 2, random (-30, 30))
 		TNT1 A 0 A_SpawnItem("PlasmaSmoke")
 		Loop
-	
+
 	SpawnUnderwater:
 	    TNT1 A 0 A_ChangeFlag("NOGRAVITY", 0)
 		TNT1 A 0 A_SpawnItem("RocketFlare",-20,0)
 	    TNT1 A 0 A_CustomMissile ("BUBULZ", 0, 0, random (0, 360), 2, random (0, 180))
 	    Goto Live
-	
+
 	Death:
         TNT1 A 0
 		TNT1 A 0 A_Explode(90, 1500, 1, 1, 1400)
@@ -773,7 +772,7 @@ Species "None"
 		TNT1 AAAAAAAAAAAAA 0  A_CustomMissile ("NukeSmoke", random (50, 1200), 0, random (0, 360), 2, random(80, 90))
 		TNT1 AAA 0  A_CustomMissile ("NukeSmokeBig", 1400, 0, random (0, 360), 2, random(80, 90))
 		TNT1 A 1000
-		sTOP	
+		sTOP
 	}
 }
 
@@ -814,7 +813,7 @@ ACTOR TankShell
 	    TNT1 A 0 A_SpawnItemEx ("DetectCeilCrater",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
 	    TNT1 A 0 A_SpawnItemEx ("UnderwaterExplosion",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
         TNT1 A 0 A_SpawnItemEx ("ExplosionFlareSpawner",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
-		
+
 		TNT1 AAAAAAAAAA 0 A_CustomMissile ("BDExplosionparticlesBig", 0, 0, random (0, 360), 2, random (0, 360))
 		TNT1 AAAAAA 0 A_CustomMissile ("TankExplosionFlames", 0, 0, random (0, 360), 2, random (0, 90))
 		TNT1 AA 0 A_CustomMissile ("TankExplosionFlames", 0, 0, random (0, 360), 2, random (0, 90))

--- a/MENUDEF.TXT
+++ b/MENUDEF.TXT
@@ -28,7 +28,7 @@ IfGame(Doom, Chex)
 		StaticPatch 278, 80, "FBULA0"
 		Position 110, 56
 	}
-	
+
 	IfGame(Doom, Strife, Chex)
 	{
 		TextItem "New Game", "n", "PlayerclassMenu"
@@ -54,7 +54,7 @@ IfGame(Doom, Chex)
 		}
 		TextItem "Quit Game", "q", "QuitMenu"
 	}
-	
+
 	IfGame(Heretic, Hexen)
 	{
 		TextItem "$MNU_NEWGAME", "n", "PlayerclassMenu"
@@ -99,7 +99,7 @@ OptionMenu "BrutalDoomOptionsPerformance"
    StaticText "All changes made here have immediate effect."
    StaticText " "
   Option "Current Sourceport", "isrunningzandronum", "SelectEngineType"
-  StaticText "To ensure maximum compatibility, select the" 
+  StaticText "To ensure maximum compatibility, select the"
   StaticText "sourceport you are using to run Brutal Doom."
   StaticText " "
   Option "Max Wall Decals", "cl_maxdecals", "maxdecals"
@@ -332,9 +332,9 @@ OptionMenu "BDCredits1"
    StaticText "EletricPulse, Mr. Enchanter, Doom_Jedi, Kamijou"
    StaticText "Kars van Kouwen, scalliano, Tomtefars, Das_M,"
    StaticText "Azona, Bret Arts, 3D Realms, Raven Software."
-   StaticText "" 
+   StaticText ""
    StaticText "==== Code Contributions ===="
-   StaticText "TerminusEst13, Solarsnowfall, Nash, Jekyll Grim Payne" 
+   StaticText "TerminusEst13, Solarsnowfall, Nash, Jekyll Grim Payne"
    StaticText " "
    StaticText "==== Voice Acting ===="
    StaticText "Zero X. Diamond (Doomguy), Tiberium Soul (Marines)"
@@ -359,14 +359,14 @@ OptionMenu "BDCredits2"
    StaticText " "
    StaticText "= V21 Testing Team (list still incomplete) ="
    StaticText "Cairn (El_Jefe) Moczygemba, Bog, TheZombie, LadySlash"
-   StaticText "FusedQYou, BXN, Erebus, Miles, Jaylen (Pyrolex) Leu"	
+   StaticText "FusedQYou, BXN, Erebus, Miles, Jaylen (Pyrolex) Leu"
    StaticText "Jess-James (scaryred24) Medeiros, Spart_N"
    StaticText "ManofDom, Brandon (Keeper), Deathlock176,"
    StaticText "Sir Fagtrixxx, Iddqd, Supra107, JeffSturm4nn,"
    StaticText "Jose (TootsyBowl) Lee, Joji (Battore) Iriefu,"
-   StaticText "Marcin (Martinoz) Oprzadek,"   
-   StaticText "Dantos, Enrico Alessandro (ZioMcCall) Marino,"  
-   StaticText "blackmore103, SoulCircle, NexGuy"  
+   StaticText "Marcin (Martinoz) Oprzadek,"
+   StaticText "Dantos, Enrico Alessandro (ZioMcCall) Marino,"
+   StaticText "blackmore103, SoulCircle, NexGuy"
    StaticText " "
    StaticText "In case of missing names, please PM them to me either"
    StaticText "in Twitter, Discord, Moddb, Doomworld, or Zandronum forums"

--- a/Tracers.txt
+++ b/Tracers.txt
@@ -6,7 +6,6 @@ Actor Tracer: FastProjectile
 	+RANDOMIZE
 	+FORCEXYBILLBOARD
 	+DONTSPLASH
-	// +BLOODSPLATTER 
 	+NOEXTREMEDEATH
 	damage 0
 	radius 2
@@ -27,11 +26,11 @@ Actor Tracer: FastProjectile
 			//TNT1 A 0 A_JumpIfInTargetInventory("IsTacticalClass", 1, "Tactical")
 			tnt1 a 2
 			Stop
-			
+
 		XDeath:
 			TNT1 A 0
 			Stop
-		
+
 		Tactical:
 			TNT1 A 0
 			TNT1 A 0 A_Explode(8, 50)
@@ -51,8 +50,7 @@ Actor DecorativeTracer: Tracer
 
 Actor MonsterTracer: Tracer
 {
-+BLOODSPLATTER 
-+THRUGHOST
++BLOODSPLATTER
 -DONTSPLASH
 +MISSILE
 -DONTHURTSPECIES
@@ -68,22 +66,22 @@ States
 		TNT1 A 0 ThrustThingZ(0,random(-8, 8),0,1)
 		TRAC A 1 BRIGHT
 		Goto Spawn2
-		
+
 	Spawn2:
 		TRAC A 1 BRIGHT
-		Loop	
-		
+		Loop
+
 Death:
     TNT1 A 1 A_SpawnItem("HitPuffTracer")
 	//TNT1 A 0 A_SpawnItemEx ("MonsterPenetrator",cos(-pitch)*25,0,0+(sin(pitch)*25),cos(-pitch)*100,0,sin(pitch)*100,0,SXF_TRANSFERPITCH)
     TNT1 A 0
 	TNT1 A 0 //A_PlaySound("bulletwhistle")
 	Stop
-	
+
 XDeath:
     TNT1 A 0
 	TNT1 A 0 //A_PlaySound("bulletwhistle")
-	Stop	
+	Stop
 }
 }
 
@@ -91,8 +89,7 @@ XDeath:
 
 Actor ShotgunguyTracer: Tracer
 {
-+BLOODSPLATTER 
-+THRUGHOST
++BLOODSPLATTER
 -DONTSPLASH
 +MISSILE
 damage (random(12,12))
@@ -105,22 +102,22 @@ States
 		TNT1 A 0 ThrustThingZ(0,random(-8, 8),0,1)
 		TRAC A 1 BRIGHT
 		Goto Spawn2
-		
+
 	Spawn2:
 		TRAC A 1 BRIGHT
-		Loop	
-		
+		Loop
+
 	Death:
     TNT1 A 1 A_SpawnItem("HitPuffTracer")
 	//TNT1 A 0 A_SpawnItemEx ("MonsterPenetrator",cos(-pitch)*25,0,0+(sin(pitch)*25),cos(-pitch)*100,0,sin(pitch)*100,0,SXF_TRANSFERPITCH)
     TNT1 A 0
 	TNT1 A 0 //A_PlaySound("bulletwhistle")
 	Stop
-	
+
 	XDeath:
     TNT1 A 0
 	TNT1 A 0 //A_PlaySound("bulletwhistle")
-	Stop	
+	Stop
 }
 }
 
@@ -132,8 +129,7 @@ damage (random(11,11))
 
 Actor MonsterMinigunTracer: MonsterTracer
 {
-+BLOODSPLATTER 
-+THRUGHOST
++BLOODSPLATTER
 -DONTSPLASH
 speed 50
 
@@ -146,7 +142,7 @@ States
 {
 Spawn:
 		TRAC A 1 BRIGHT
-		
+
 		TRAC A -1 BRIGHT
 		Loop
 	Death:
@@ -155,11 +151,11 @@ Spawn:
     TNT1 A 0
 	TNT1 A 0 //A_PlaySound("bulletwhistle")
 	Stop
-	
+
 	XDeath:
     TNT1 A 0
 	TNT1 A 0 //A_PlaySound("bulletwhistle")
-	Stop	
+	Stop
 }
 }
 
@@ -180,7 +176,7 @@ States
 Death:
     TNT1 A 1 A_SpawnItem("HitPuffTracer")
     Stop
-	
+
 Spawn:
 	TRAC A 1 BRIGHT
 	Loop
@@ -190,8 +186,7 @@ Spawn:
 
 Actor MarineTracer: Tracer
 {
-+BLOODSPLATTER 
-+THRUGHOST
++BLOODSPLATTER
 +MTHRUSPECIES
 -DONTSPLASH
 -GHOST
@@ -210,7 +205,7 @@ XDEath:
 TNT1 A 0
 //TNT1 A 0 A_Explode(2, 5)
 TNT1 A 1
-Stop	
+Stop
 }
 }
 
@@ -224,10 +219,10 @@ States
 		TNT1 A 0 ThrustThingZ(0,random(-9, 9),0,1)
 		TRAC A 1 BRIGHT
 		Goto Spawn2
-		
+
 	Spawn2:
 		TRAC A 1 BRIGHT
-		Loop	
+		Loop
 }
 }
 
@@ -243,10 +238,10 @@ States
 		TNT1 A 0 ThrustThingZ(0,random(-9, 9),0,1)
 		TRAC A 1 BRIGHT
 		Goto Spawn2
-		
+
 	Spawn2:
 		TRAC A 1 BRIGHT
-		Loop	
+		Loop
 }
 }
 
@@ -254,8 +249,7 @@ States
 
 Actor Alerter: MonsterTracer
 {
--BLOODSPLATTER 
-+THRUGHOST
+-BLOODSPLATTER
 +DONTSPLASH
 -ACTIVATEIMPACT
 -ACTIVATEMCROSS
@@ -304,8 +298,8 @@ States
 	TNT1 A 0
 	TNT1 A 0 A_Stop
     TNT1 A 0
-    Stop	
-		
+    Stop
+
 }
 }
 
@@ -313,8 +307,7 @@ States
 Actor Taunter: MonsterTracer
 {
 
--BLOODSPLATTER 
-+THRUGHOST
+-BLOODSPLATTER
 +DONTSPLASH
 radius 16
 height 16
@@ -333,14 +326,14 @@ States
 		PUZZ Z 1 BRIGHT
 		Loop
 XDeath:
-Melee:		
+Melee:
 Death:
     TNT1 A 1
 	//TNT1 AAAA 0 A_CustomMissile ("LongExplosionSpawner", 20, 0, random (0, 360), 2, random (0, 180))
     //TNT1 AAAAAA 0 A_CustomMissile ("ExplosionSpawner", 20, 0, random (0, 180), 2, random (0, 180))
 	//TNT1 AAAAA 0 A_SpawnItem("BarrelExplosion")
 	TNT1 A 100
-	
+
 	Stop
 }
 }
@@ -351,8 +344,7 @@ Death:
 
 Actor MastermindTracer: Tracer
 {
-+BLOODSPLATTER 
-+THRUGHOST
++BLOODSPLATTER
 -DONTSPLASH
 +FORCERADIUSDMG
 speed 80
@@ -420,7 +412,7 @@ States
 Actor SuperMastermindTracer: MastermindTracer
 {
 Speed 120
-Damage (random(25,30)) 
+Damage (random(25,30))
 Height 24
 }
 
@@ -462,8 +454,7 @@ actor MastermindTracerTrail18: MastermindTracerTrail {    Alpha 0.05 }
 
 Actor NaziAlerter: Tracer
 {
--BLOODSPLATTER 
-+THRUGHOST
+-BLOODSPLATTER
 speed 150
 Decal "None"
 Radius 16
@@ -599,22 +590,22 @@ States
 		TNT1 A 0 A_CustomMissile("SpawnBulletDecalBackwards", 0, 0, 0)
 		TRAC A 10 BRIGHT
 		sTOP
-		
+
 Death:
 	TNT1 A 0
 	TNT1 A 0 A_CheckFloor("XDeath")
 	TNT1 A 0 A_CheckCeiling("XDeath")
     TNT1 A 1 A_SpawnItem("HitPuffTracer")
 	Stop
-	
-DeathSpecial:	
-	
+
+DeathSpecial:
+
     Stop
 XDEath:
 TNT1 A 0
 //TNT1 A 0 A_Explode(2, 5)
 TNT1 A 1
-Stop	
+Stop
 }
 }
 
@@ -649,7 +640,7 @@ XDEath:
 TNT1 A 0
 //TNT1 A 0 A_Explode(2, 5)
 TNT1 A 1
-Stop	
+Stop
 }
 }
 
@@ -672,14 +663,14 @@ Death:
 	TNT1 A 0
 	TNT1 A 0 A_CheckFloor("XDeath")
 	TNT1 A 0 A_CheckCeiling("XDeath")
-	
+
     TNT1 A 1 A_SpawnItem("HitPuffTracer")
     Stop
 XDEath:
 TNT1 A 0
 //TNT1 A 0 A_Explode(2, 5)
 TNT1 A 1
-Stop	
+Stop
 }
 }
 


### PR DESCRIPTION
Fixes #159 
So if the player crouches the Cyberdemon Missile will begin to hit the Barons body hitbox which told me the missile was passing through the headshot actors (which are ghosts).  So, removed the +THRUGHOST flag from Cyberballs and any tracer projectile that had the flag as well so that they will hit monster head hitboxes now.