### PR TITLE
Adding RZDoom along with Zandronum

### DIFF
--- a/MENUDEF.TXT
+++ b/MENUDEF.TXT
@@ -270,7 +270,7 @@ OptionValue "YesOrNoFalse"
 
 OptionValue "SelectEngineType"
 {
-	1, "Zandronum"
+	1, "Zandronum/RZDoom"
 	0, "GZDoom/LZDoom"
 }
 
@@ -356,7 +356,7 @@ OptionMenu "BDCredits1"
    StaticText " "
    StaticText " "
    StaticText "In case of missing names, please PM them to me either"
-   StaticText "in Twitter, Discord, Moddb, Doomworld, or Zandronum forums"
+   StaticText "in Twitter, Discord, Moddb, Doomworld, Zandronum forums or RZDoom repository"
 }
 
 OptionMenu "BDCredits2"
@@ -380,7 +380,7 @@ OptionMenu "BDCredits2"
    StaticText "blackmore103, SoulCircle, NexGuy"
    StaticText " "
    StaticText "In case of missing names, please PM them to me either"
-   StaticText "in Twitter, Discord, Moddb, Doomworld, or Zandronum forums"
+   StaticText "in Twitter, Discord, Moddb, Doomworld, Zandronum forums or RZDoom repository"
    StaticText " "
    StaticText "Special Thanks To Andrew Hulshult, Finfr0sk"
    StaticText "John Romero, Bethesda's Doom Community Managers"

--- a/modeldef.blood.txt
+++ b/modeldef.blood.txt
@@ -1,5 +1,5 @@
-//Unfortunately, Zandronum still doesn't supports flat sprites, so to ensure that the mode can work
-//both on GZDoom and Zandronum, it's still necessary to use 3D models.
+//Unfortunately, Zandronum/RZDoom still doesn't supports flat sprites, so to ensure that the mode can work
+//both on GZDoom and Zandronum/RZDoom, it's still necessary to use 3D models.
 
 
 Model Guts      // Name of actor in DECORATE

--- a/modeldef.blueblood.txt
+++ b/modeldef.blueblood.txt
@@ -1,5 +1,5 @@
-//Unfortunately, Zandronum still doesn't supports flat sprites, so to ensure that the mode can work
-//both on GZDoom and Zandronum, it's still necessary to use 3D models.
+//Unfortunately, Zandronum/RZDoom still doesn't supports flat sprites, so to ensure that the mode can work
+//both on GZDoom and Zandronum/RZDoom, it's still necessary to use 3D models.
 
 
 Model BlueGiantBloodSpot      // Name of actor in DECORATE

--- a/modeldef.greenblood.txt
+++ b/modeldef.greenblood.txt
@@ -1,5 +1,5 @@
-//Unfortunately, Zandronum still doesn't supports flat sprites, so to ensure that the mode can work
-//both on GZDoom and Zandronum, it's still necessary to use 3D models.
+//Unfortunately, Zandronum/RZDoom still doesn't supports flat sprites, so to ensure that the mode can work
+//both on GZDoom and Zandronum/RZDoom, it's still necessary to use 3D models.
 
 
 Model GreenGiantBloodSpot      // Name of actor in DECORATE


### PR DESCRIPTION
I am the Author of RZDoom, a 100% compatible fork on ZDoom 2.8.1 using the same Software Renderer.  I submitted this PR to have (same as GZDoom/LZDoom) a Zandronum/RZDoom text change.  I am fully prepared to support Brutal Doom CE on RZDoom and this text change allows users to see other fully supported source ports other than Zandro/GZ/LZ.

For information, RZDoom is currently fully capable of running it.