### PR TITLE
Some more fixes and corrections

### DIFF
--- a/Demons.txt
+++ b/Demons.txt
@@ -816,6 +816,168 @@ States
 		SG1A GGG 3
 		Goto See
 
+	Death.HeavyImpact:
+		TNT1 A 0
+		TNT1 A 0 A_FaceTarget
+		TNT1 A 0 A_Recoil(5)
+		TNT1 A 0 ThrustThingZ(0,20,0,1)
+		Goto CleanDeath
+			
+	Death.SSG:
+	Death.Railgun:
+		TNT1 A 0
+		TNT1 A 0 A_Stop
+	    SARC A 1 A_Pain
+	    SARC A 1 A_FaceTarget
+
+	    TNT1 AAA 0 bright A_CustomMissile ("SuperGoreSpawner", 35, 0, random (170, 190), 2, random (0, 40))
+        //TNT1 A 0 A_CustomMissile ("MeatDeath", 0, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AAAA 0 A_CustomMissile ("XDeath2", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAA 0 A_CustomMissile ("XDeath3", 32, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAAAA 0 A_CustomMissile ("BloodMistBig", 40, 0, random (0, 360), 2, random (40, 90))
+		TNT1 AA 0 A_CustomMissile ("BloodMistExtraBig", 40, 0, random (0, 360), 2, random (40, 90))
+		TNT1 AA 0 A_CustomMissile ("pinkyheadPiece", 42, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("PinkyJaw", 42, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("XDeathDemonArm", 32, 0, random (170, 190), 2, random (0, 40))
+        TNT1 A 0 A_XScream
+		TNT1 A 0 A_NoBlocking
+        SARC AAABBBCCCDDD 3 A_CustomMissile ("Brutal_LiquidBlood", 35, 0, random (0, 360), 2, random (30, 110))
+		TNT1 A 0 A_SpawnItem ("GrowingBloodPool")
+		SARC DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD 2 A_CustomMissile ("Brutal_LiquidBlood", 15, 0, random (0, 360), 2, random (30, 110))
+		SARC D 0 A_SpawnItem("DeadDemonHalf23")
+		TNT1 A -1
+        Stop
+
+	Death.GreenFire:
+        TNT1 A 0
+        TNT1 A 0 A_XScream
+        TNT1 A 0 A_NoBlocking
+        TNT1 AAAAA 0 A_CustomMissile ("BloodMistBig", 40, 0, random (0, 360), 2, random (40, 90))
+
+	    TNT1 A 0 A_CustomMissile ("XDeathBurnedDemonArm", 32, 0, random (0, 360), 2, random (0, 160))
+	    TNT1 A 0 A_CustomMissile ("XDeathBurnedDemonLeg", 32, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("XDeathBurnedMeat", 32, 0, random (0, 360), 2, random (0, 160))
+	    TNT1 A 0 A_CustomMissile ("XDeathBurnedMeat2", 32, 0, random (0, 360), 2, random (0, 160))
+	    TNT1 A 0 A_CustomMissile ("XDeathBurnedMeat3", 32, 0, random (0, 360), 2, random (0, 160))
+
+		EXPL AAAAAAAAAAAAAAAAAAAAAAAA 0 A_CustomMissile ("GreenFlameTrails", 50, 0, random (0, 360), 2, random (0, 360))
+		XBRN AAAA 2 BRIGHT A_SpawnItem("GreenFlare",0,43)
+        Stop
+
+	Death.SuperPlasma:
+    Death.Plasma: Death.Plasma2:
+        TNT1 A 0 A_Stop
+        TNT1 A 0 A_XScream
+        TNT1 A 0 A_NoBlocking
+
+	    TNT1 A 0 A_CustomMissile ("XDeathBurnedDemonArm", 32, 0, random (0, 360), 2, random (0, 160))
+	    TNT1 A 0 A_CustomMissile ("XDeathBurnedDemonLeg", 32, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AAAA 0 A_CustomMissile ("BluePlasmaFireNonStatic", 42, 0, random (0, 360), 2, random (0, 180))
+		TNT1 AAA 0 A_CustomMissile ("Blood", 32, 0, random (0, 360), 2, random (0, 180))
+		TNT1 AAA 0 A_CustomMissile ("BloodMistSmall", 32, 0, random (0, 360), 2, random (0, 180))
+		TNT1 AAA 0 A_CustomMissile ("Brutal_FlyingBlood", 32, 0, random (0, 360), 2, random (0, 180))
+		TNT1 A 0 A_SpawnItemEx ("DetectFloorCraterSmall",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+		TNT1 A 0 A_SpawnItem("BarrelExplosionSmokeColumn")
+		TNT1 A 0 A_SpawnItemEx("TinyBurningPiece", random (-15, 15), random (-15, 15))
+		TNT1 AA 0 A_SpawnItemEx("TinyBurningPiece2", random (-35, 35), random (-35, 35))
+		TNT1 AA 0 A_SpawnItemEx("TinyBurningPiece3", random (-45, 45), random (-45, 35))
+        //SPRG ABCDEF 6
+        TNT1 A 0 A_SpawnItem("BurnedDemon")
+        Stop
+
+	Death.Fire:
+        TNT1 A 0
+		TNT1 A 0 A_Scream
+        TNT1 A 0 A_NoBlocking
+		TNT1 A 0 A_CustomMissile ("XDeathBurnedDemonLeg", 32, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AAA 0 A_CustomMissile ("Blood", 32, 0, random (0, 360), 2, random (0, 180))
+		TNT1 AAA 0 A_CustomMissile ("BloodMistSmall", 32, 0, random (0, 360), 2, random (0, 180))
+		TNT1 AAA 0 A_CustomMissile ("Brutal_FlyingBlood", 32, 0, random (0, 360), 2, random (0, 180))
+		TNT1 A 0 A_SpawnItemEx ("DetectFloorCraterSmall",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
+		TNT1 A 0 A_SpawnItem("BarrelExplosionSmokeColumn")
+		TNT1 A 0 A_SpawnItemEx("TinyBurningPiece", random (-15, 15), random (-15, 15))
+		TNT1 AA 0 A_SpawnItemEx("TinyBurningPiece2", random (-35, 35), random (-35, 35))
+		TNT1 AA 0 A_SpawnItemEx("TinyBurningPiece3", random (-45, 45), random (-45, 35))
+        TNT1 A 0 A_SpawnItem("BurnedDemon")
+        Stop
+
+	Death.Shrapnel:
+		TNT1 A 0
+		TNT1 A 0 ThrustThingZ(0, 30, 0, 0)
+		TNT1 A 0 A_Jump(128, "Death.Strong2")
+		TNT1 A 0 A_SpawnItem("MuchBlood", 0, 32)
+		Goto Death
+		
+	Death.Desintegrate:
+	Death.RVFT:
+	Death.BHFT:
+	Death.SuperPunch:
+	Death.ExtremePunches:
+	Death.ExplosiveImpact:
+	XDeath:
+	Death.Explosive:
+	    TNT1 A 0 A_XScream
+		TNT1 A 0 A_NoBlocking
+		TNT1 A 0 A_FaceTarget
+		TNT1 AAA 0 A_CustomMissile ("XDeath1", 42, 0, random (0, 190), 2, random (10, 60))
+		TNT1 AAAA 0 A_CustomMissile ("XDeath3", 42, 0, random (0, 190), 2, random (10, 60))
+		TNT1 AAA 0 A_CustomMissile ("XDeath2", 42, 0, random (0, 190), 2, random (10, 60))
+		TNT1 A 0 A_CustomMissile ("XDeath4", 42, 0, random (0, 190), 2, random (10, 60))
+	    TNT1 A 0 A_CustomMissile ("Brains2", 50, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("XDeathStomach", 32, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AA 0 A_CustomMissile ("XDeathBullLeg12", 32, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("XDeathDemonArm", 32, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AAA 0 A_CustomMissile ("XDeath2b", 32, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AAA 0 A_CustomMissile ("XDeath3b", 32, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("XDeathPinkyDemonHead", 42, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AAA 0 A_CustomMissile ("BloodMistLarge", 40, 0, random (0, 360), 2, random (20, 90))
+		Stop
+	BlownAwayLeft:
+		TNT1 A 0
+	    TNT1 A 0 A_NoBlocking
+		TNT1 A 0 A_CustomMissile ("XDeath1", 32, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("XDeath2", 32, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_ChangeFlag("NOBLOCKMONST", 1)
+	    TNT1 A 0 A_CustomMissile ("Brains2", 50, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("XDeathStomach", 32, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AA 0 A_CustomMissile ("XDeathBullLeg12", 32, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("XDeathDemonArm", 32, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AAA 0 A_CustomMissile ("XDeath2b", 32, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AAA 0 A_CustomMissile ("XDeath3b", 32, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("XDeathPinkyDemonHead", 42, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AAA 0 A_CustomMissile ("BloodMistLarge", 40, 0, random (0, 360), 2, random (20, 90))
+		TNT1 A 0 ThrustThingZ(0,30,0,1)
+		TNT1 A 0 A_Xscream
+	    TNT1 A 0 A_CustomMissile ("Brutal_FlyingBlood", 0, 0, 0, 2, 90)
+	BlownAwayRight:
+		TNT1 A 0 A_NoBlocking
+		TNT1 A 0 A_CustomMissile ("XDeath1", 32, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("XDeath2", 32, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_ChangeFlag("NOBLOCKMONST", 1)
+	    TNT1 A 0 A_CustomMissile ("Brains2", 50, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("XDeathStomach", 32, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AA 0 A_CustomMissile ("XDeathBullLeg12", 32, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("XDeathDemonArm", 32, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AAA 0 A_CustomMissile ("XDeath2b", 32, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AAA 0 A_CustomMissile ("XDeath3b", 32, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("XDeathPinkyDemonHead", 42, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AAA 0 A_CustomMissile ("BloodMistLarge", 40, 0, random (0, 360), 2, random (20, 90))
+		TNT1 A 0 ThrustThingZ(0,30,0,1)
+		TNT1 A 0 A_Xscream
+	    TNT1 A 0 A_CustomMissile ("Brutal_FlyingBlood", 0, 0, 0, 2, 90)
+		Stop
+
+	Death.KillMe:
+    Death.Taunt:
+	    TNT1 A 0 A_ChangeFlag("SOLID", 0)
+        TNT1 A 0 A_SpawnItem("ArmlessDemon")
+        Stop
+		
+	Death.Strong:
+	Death.Strong2:
+	Death.Fatality:
+	Death.HelperMarineFatallity:
+	Death.SuperKick:
 	Death.Saw:
 	Death.Cut:
 	Death.Shotgun:
@@ -833,7 +995,10 @@ States
 		SAAR I 0 A_SpawnItem("DeadDemonSAARI")
 		TNT1 A -1
         Stop
-
+		
+	Death.Melee:
+	Death.Minor:
+	CleanDeath:
 	Death:
 	Death.Kick:
 	    TNT1 A 0 A_Scream
@@ -842,7 +1007,7 @@ States
 		TNT1 A 0 A_SpawnItem ("DeadDemonNoArm", 5)
 		TNT1 A 0 A_SpawnItem ("GrowingBloodPool")
 		Stop
-		}
+	}
 }
 
 Actor DeadDemon1: CurbstompedMarine Replaces DeadDemon

--- a/Zombiemen.txt
+++ b/Zombiemen.txt
@@ -2210,7 +2210,7 @@ ACTOR DyingZombieman
 			ZMAD B 0 A_XScream
 			TNT1 A 0 A_SpawnItemEx("HealthCrueltyBonus2", 0, 0, 8, frandom (-2.5, 2.5), frandom (-2.5, 2.5), 5)
 			ZMAD C 0 A_NoBlocking
-			TNT1 A 0 A_SpawnItem("DeadZombieman_Noheadfront")
+			TNT1 A 0 A_SpawnItem("DeadZombieman_NoLegNoHead")
 			Stop
 
 		Death.Stomp:


### PR DESCRIPTION
Fixed an issue where the one-armed Hell Bull spawns an actor or plays an animation with both of his arms remain intact when he reaches the missing death states
The crawling zombieman now spawns the no leg no head actor when you shoot him with a shotgun