### PR TITLE
Changes to zombies and their head gib

### DIFF
--- a/GOREGROUPS.txt
+++ b/GOREGROUPS.txt
@@ -64,6 +64,55 @@ ACTOR ZombieXDeath
 	}
 }
 
+ACTOR ZombieXDeathSplattered: ZombieXDeath
+{
+    Radius 1
+    Height 1
+    Scale 0.8
+	Speed 0
+	Mass 1
+	Decal BloodSuper
+	BounceFactor 0.5
+	+DOOMBOUNCE
+	+MISSILE
+    +NOBLOCKMAP
+    +NOTELEPORT
+    +MOVEWITHSECTOR
+    +NOGRAVITY
+    +NOCLIP
+    +DONTSPLASH
+    States
+    {
+    Spawn:
+	     TNT1 A 0
+		 TNT1 A 0 A_Pain
+		 TNT1 A 0 A_FaceTarget
+
+		 TNT1 AAAAAA 0 A_CustomMissile ("WaterBloodCHecker", 24, 0, random (0, 360), 2, random (30, 60))
+	     TNT1 AAAAA 0 A_CustomMissile ("SuperWallRedBlood", 40, 0, random (0, 360), 2, random (-15, 15))
+	     TNT1 AAAAAAAAA 0 A_CustomMissile ("CeilBloodLauncherLong", 0, 0, random (0, 360), 2, random (50, 130))
+		 TNT1 AA 0 A_CustomMissile ("XDeath1", 32, 0, random (0, 360), 2, random (10, 90))
+		 TNT1 A 0 A_CustomMissile ("XDeathHalfZombiemanNoArmNoHead", 48, 0, random (0, 360), 2, random (10, 90))
+		 TNT1 AAA 0 A_CustomMissile ("SuperGoreSpawner", 30, 0, random (0, 360), 2, random (30, 60))
+		 TNT1 AAAA 0 A_CustomMissile ("XDeath2b", 15, 0, random (0, 360), 2, random (10, 90))
+		 TNT1 AAAA 0 A_CustomMissile ("XDeath3b", 15, 0, random (0, 360), 2, random (10, 90))
+		 TNT1 AA 0 A_CustomMissile ("XDeathSkinPiece2", 15, 0, random (0, 360), 2, random (10, 90))
+		 TNT1 AA 0 A_CustomMissile ("XDeathSkinPiece1", 15, 0, random (0, 360), 2, random (10, 90))
+		 TNT1 A 0 A_CustomMissile ("XDeathOrgan1", 24, 0, random (0, 360), 2, random (10, 90))
+		 TNT1 A 0 A_CustomMissile ("XDeathOrgan2", 24, 0, random (0, 360), 2, random (10, 90))
+		 TNT1 AAAAAAA 0 A_CustomMissile ("Guts", 32, 0, random (0, 360), 2, random (60, 90))
+		 TNT1 A 0 A_CustomMissile ("XDeathZombieLeg", 32, 0, random (0, 360), 2, random (10, 90))
+		 TNT1 A 0 A_CustomMissile ("GibZombieBoot", 32, 0, random (0, 360), 2, random (10, 90))
+		 TNT1 A 0 A_CustomMissile ("XDeathZombiemanHeadOnXDeath", 32, 0, random (0, 360), 2, random (10, 90))
+		 TNT1 A 0 A_SpawnItem ("BigBloodSpot")
+		 TNT1 AAAAAA 0 A_CustomMissile ("BloodMistExtraBig", 30, 0, random (0, 360), 2, random (40, 90))
+		 TNT1 A 1
+		 TNT1 A 0 ACS_NamedExecuteAlways("BD_CheckBloodIntensity", 0, 0, 0, 0)//Check Blood density
+		 TNT1 A 2
+		 Stop
+	}
+}
+
 ACTOR SargeXDeath
 {
     Radius 1
@@ -126,6 +175,53 @@ ACTOR SargeXDeath
 		TNT1 AAAAAAAAAAAA 0 A_CustomMissile ("SuperGoreMist", 24, 0, random (0, 360), 2, random (30, 90))
 		TNT1 AAAAAAAA 0 A_CustomMissile ("SuperGoreSpawner2", 64, 0, random (0, 360), 2, random (20, 40))
 		Stop
+    }
+}
+
+ACTOR SargeXDeathSplattered: SargeXDeath
+{
+    Radius 1
+    Height 1
+    Scale 0.8
+	Speed 0
+	Mass 1
+	Decal BloodSuper
+	BounceFactor 0.5
+	+DOOMBOUNCE
+	+MISSILE
+    +NOBLOCKMAP
+    +NOTELEPORT
+    +MOVEWITHSECTOR
+    +NOGRAVITY
+    +NOCLIP
+    +DONTSPLASH
+    States
+    {
+    Spawn:
+
+		TNT1 AAAAAA 0 A_CustomMissile ("WaterBloodCHecker", 24, 0, random (0, 360), 2, random (30, 60))
+	    TNT1 AAAAA 0 A_CustomMissile ("SuperWallRedBlood", 40, 0, random (0, 360), 2, random (-15, 15))
+         TNT1 AAAAAAAAA 0 A_CustomMissile ("CeilBloodLauncherLong", 0, 0, random (0, 360), 2, random (50, 130))
+		 TNT1 AA 0 A_CustomMissile ("XDeath1", 32, 0, random (0, 360), 2, random (10, 90))
+		 TNT1 AAA 0 A_CustomMissile ("SuperGoreSpawner", 30, 0, random (0, 360), 2, random (30, 60))
+		 TNT1 AAAA 0 A_CustomMissile ("XDeath2b", 15, 0, random (0, 360), 2, random (10, 90))
+		 TNT1 AAAA 0 A_CustomMissile ("XDeath3b", 15, 0, random (0, 360), 2, random (10, 90))
+		 TNT1 AA 0 A_CustomMissile ("XDeathSkinPiece2", 15, 0, random (0, 360), 2, random (10, 90))
+		 TNT1 AA 0 A_CustomMissile ("XDeathSkinPiece1", 15, 0, random (0, 360), 2, random (10, 90))
+		 TNT1 A 0 A_CustomMissile ("XDeathOrgan1", 24, 0, random (0, 360), 2, random (10, 90))
+		 TNT1 A 0 A_CustomMissile ("XDeathOrgan2", 24, 0, random (0, 360), 2, random (10, 90))
+		 TNT1 A 0 A_CustomMissile ("XDeathHalfShotgunguyNoArmNoHead", 32, 0, random (0, 360), 2, random (10, 90))
+		 TNT1 AAAAAAA 0 A_CustomMissile ("Guts", 32, 0, random (0, 360), 2, random (60, 90))
+		 TNT1 A 0 A_CustomMissile ("XDeathSargeLeg2", 32, 0, random (0, 360), 2, random (10, 90))
+		 TNT1 A 0 A_CustomMissile ("GibSargeBoot", 32, 0, random (0, 360), 2, random (10, 90))
+		 TNT1 A 0 A_CustomMissile ("XDeathSergeantHeadOnXDeath", 32, 0, random (0, 360), 2, random (10, 90))
+		 TNT1 A 0 A_SpawnItem ("BigBloodSpot")
+
+		 TNT1 A 1
+		 TNT1 AAAAAA 0 A_CustomMissile ("BloodMistExtraBig", 30, 0, random (0, 360), 2, random (40, 90))
+		 TNT1 A 0 ACS_NamedExecuteAlways("BD_CheckBloodIntensity", 0, 0, 0, 0)//Check Blood density
+		 TNT1 A 2
+		 Stop
     }
 }
 

--- a/Limbs.txt
+++ b/Limbs.txt
@@ -2654,6 +2654,7 @@ actor ZombiemanHead: LimbBase
 	Death.Melee:
 		TNT1 A 0
 		TNT1 A 0 A_NoBlocking
+		TNT1 A 0 A_JumpIfInTargetInventory("ShotgunguyHead", 1, "Death")
 		TNT1 A 0 A_GiveToTarget("ShotgunguyHead", 1)
 		Stop
 	Death.Headkick:
@@ -2797,6 +2798,7 @@ Spawn:
 	Death.Melee:
 		TNT1 A 0
 		TNT1 A 0 A_NoBlocking
+		TNT1 A 0 A_JumpIfInTargetInventory("ShotgunguyHead", 1, "Death")
 		TNT1 A 0 A_GiveToTarget("ShotgunguyHead", 1)
 		Stop
 

--- a/Sergeants.txt
+++ b/Sergeants.txt
@@ -3078,8 +3078,6 @@ ACTOR SergeantFallingSplattered
 	Death:
 	Death.Shotgun:
 	Death.SSG:
-	XDeath:
-	Death.SSG:
 		TNT1 A 0
 		TNT1 A 0 A_Stop
 		ZZD1 E 1 A_Pain
@@ -3117,7 +3115,7 @@ ACTOR SergeantFallingSplattered
 		TNT1 AAA 0 A_CustomMissile ("XDeath3", 42, 0, random (0, 290), 2, random (10, 60))
 		TNT1 A 0 A_CustomMissile ("XDeath2", 42, 0, random (0, 190), 2, random (10, 60))
 		TNT1 A 0 A_CustomMissile ("XDeath4", 42, 0, random (0, 190), 2, random (10, 60))
-        TNT1 A 0 A_CustomMissile ("SargeXDeath", 2, 0, random (0, 360), 2, random (0, 160))
+        TNT1 A 0 A_CustomMissile ("SargeXDeathSplattered", 2, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_SpawnItemEx("HealthCrueltyBonus2", 0, 0, 20, frandom (-2.5, 2.5), frandom (-2.5, 2.5), 5)
 		Stop
 

--- a/Zombiemen.txt
+++ b/Zombiemen.txt
@@ -2766,6 +2766,19 @@ ACTOR ZombiemanFallingBeheaded
 		TNT1 A 0 A_CustomMissile ("ArterialBloodSPray", 10, -10, 45, 2, random (0, 60))
 		TNT1 A 0 A_SpawnItemEx("HealthCrueltyBonus2", 0, 0, 20, frandom (-2.5, 2.5), frandom (-2.5, 2.5), 5)
 		Stop
+	
+	Death.Kick:
+		TNT1 A 0 A_Noblocking
+		TNT1 A 0 A_Scream
+		TNT1 A 0 A_FaceTarget
+		TNT1 A 0 A_SpawnItem ("GrowingBloodPool")
+        TNT1 A 0 A_CustomMissile ("ArterialBloodSPray", 10, -10, 45, 2, random (0, 60))
+		TNT1 A 0 A_SpawnItemEx("HealthCrueltyBonus2", 0, 0, 20, frandom (-2.5, 2.5), frandom (-2.5, 2.5), 5)
+		TNT1 A 0 A_Recoil(10)
+		TNT1 A 0 ThrustThingZ(0,35,0,1)
+		POSL GHIJK 6
+		TNT1 A 0 A_SpawnItem ("DeadZombiemanPOSLL")
+		Stop
 
 	Death.SSG:
 	XDeath:
@@ -2932,8 +2945,6 @@ ACTOR ZombiemanFallingSplattered
 	Death:
 	Death.Shotgun:
 	Death.SSG:
-	XDeath:
-	Death.SSG:
 		TNT1 A 0
 		TNT1 A 0 A_Stop
 		ZZD1 E 1 A_Pain
@@ -2971,7 +2982,7 @@ ACTOR ZombiemanFallingSplattered
 		TNT1 AAA 0 A_CustomMissile ("XDeath3", 42, 0, random (0, 290), 2, random (10, 60))
 		TNT1 A 0 A_CustomMissile ("XDeath2", 42, 0, random (0, 190), 2, random (10, 60))
 		TNT1 A 0 A_CustomMissile ("XDeath4", 42, 0, random (0, 190), 2, random (10, 60))
-        TNT1 A 0 A_CustomMissile ("ZombieXDeath", 2, 0, random (0, 360), 2, random (0, 160))
+        TNT1 A 0 A_CustomMissile ("ZombieXDeathSplattered", 2, 0, random (0, 360), 2, random (0, 160))
 		TNT1 A 0 A_SpawnItemEx("HealthCrueltyBonus2", 0, 0, 20, frandom (-2.5, 2.5), frandom (-2.5, 2.5), 5)
 		Stop
 


### PR DESCRIPTION
When the shotgun-splattered sergeants and zombies reach their XDeath state, they weren't supposed to spawn two arms so I fixed this one 
Added a Death.Kick state for the falling (or barely standing) beheaded zombieman. 
Fixed an issue where the zombie heads disappear without a trace when a player, who already has one in their hand, punches them