### PR TITLE
Fix dying beheaded imps

### DIFF
--- a/Imps.txt
+++ b/Imps.txt
@@ -1652,7 +1652,6 @@ Actor DeadImp_NoStomachNoHead: DeadImp
         Stop
        Death:
 			TNT1 A 0 A_NoBlocking
-			TNT1 A 0 A_SpawnItem("ImpHeadExplode", 0, 10)
 			TNT1 A 0 A_SpawnItem("DeadImp_NoHead")
 			Stop}}
 
@@ -2356,6 +2355,7 @@ Damagefactor "Head", 0.0
 
 ACTOR DyingImpNoHeadLikeChicken: DyingImp
 {
+Damagefactor "Head", 0.0
 	States
 	{
     Spawn:
@@ -2411,6 +2411,7 @@ ACTOR DyingImpNoHeadLikeChicken: DyingImp
 
 ACTOR DyingImpNoHeadNoArmContinue: DyingImp
 {
+Damagefactor "Head", 0.0
 	States
 	{
 		Spawn:


### PR DESCRIPTION
There was a not-so-rare bug that caused the dying imps to look like they detached then regrew body parts, it could easily be performed with a shotgun.
This was caused by missing head damage factors for those dying headless imps. At first I thought it jumped to 2 death states at once but no, it was the continuation variations.