### PR TITLE
Fixing another imperfection

### DIFF
--- a/Blood.txt
+++ b/Blood.txt
@@ -396,10 +396,9 @@ ACTOR BloodDripingFromCeiling: Brutal_FlyingBlood
 	Spawn:
 		TNT1 A 0
 		TNT1 A 0 A_Jump(230, "NoSpawn")
-	Live:
 		TNT1 A 0 A_JumpIf(waterlevel > 1, "Splash")
-		BLUD ZZZZZZZZZZZZZZZZZZZZZZZZZ 20 A_ChangeVelocity(0,0,(VelZ >= 0) && -1 || 0)
-		Stop
+		BLUD Z 500
+		Loop
 	Death:
 		TNT1 A 0
 		TNT1 A 0 A_PlaySound("blooddrop2")
@@ -419,10 +418,9 @@ ACTOR BloodDripingFromCeilingBig: BloodDripingFromCeiling
 	Spawn:
 		TNT1 A 0
 		TNT1 A 0 A_Jump(160, "NoSpawn")
-	Live:
 		TNT1 A 0 A_JumpIf(waterlevel > 1, "Splash")
-		BLUD ZZZZZZZZZZZZZZZZZZZZZZZZZ 20 A_ChangeVelocity(0,0,(VelZ >= 0) && -1 || 0)
-		Stop
+		BLUD Z 500
+		Loop
 	Death:
 		TNT1 A 0
 		TNT1 A 0 A_PlaySound("blooddrop2")
@@ -1042,10 +1040,9 @@ ACTOR DripingBloodLeavesPool: BloodDripingFromCeiling
 	{
 		Spawn:
 			TNT1 A 0
-		Live:
 			TNT1 A 0 A_JumpIf(waterlevel > 1, "Splash")
-			BLUD Z 20 A_ChangeVelocity(0,0,(VelZ >= 0) && -1 || 0)
-			loop
+			BLUD Z 4
+			Loop
 		Splash:
 			BLOD A 0
 			TNT1 A 0 A_CustomMissile ("Underblood2", 7, 0, random (0, 360), 2, random (30, 150))

--- a/Blood.txt
+++ b/Blood.txt
@@ -398,7 +398,7 @@ ACTOR BloodDripingFromCeiling: Brutal_FlyingBlood
 		TNT1 A 0 A_Jump(230, "NoSpawn")
 	Live:
 		TNT1 A 0 A_JumpIf(waterlevel > 1, "Splash")
-		BLUD ZZZZZZZZZZZZZZZZZZZZZZZZZ 20 A_ChangeVelocity(0,0,-1)
+		BLUD ZZZZZZZZZZZZZZZZZZZZZZZZZ 20 A_ChangeVelocity(0,0,(VelZ >= 0) && -1 || 0)
 		Stop
 	Death:
 		TNT1 A 0
@@ -421,7 +421,7 @@ ACTOR BloodDripingFromCeilingBig: BloodDripingFromCeiling
 		TNT1 A 0 A_Jump(160, "NoSpawn")
 	Live:
 		TNT1 A 0 A_JumpIf(waterlevel > 1, "Splash")
-		BLUD ZZZZZZZZZZZZZZZZZZZZZZZZZ 20 A_ChangeVelocity(0,0,-1)
+		BLUD ZZZZZZZZZZZZZZZZZZZZZZZZZ 20 A_ChangeVelocity(0,0,(VelZ >= 0) && -1 || 0)
 		Stop
 	Death:
 		TNT1 A 0
@@ -1044,7 +1044,7 @@ ACTOR DripingBloodLeavesPool: BloodDripingFromCeiling
 			TNT1 A 0
 		Live:
 			TNT1 A 0 A_JumpIf(waterlevel > 1, "Splash")
-			BLUD Z 20 A_ChangeVelocity(0,0,-1)
+			BLUD Z 20 A_ChangeVelocity(0,0,(VelZ >= 0) && -1 || 0)
 			loop
 		Splash:
 			BLOD A 0

--- a/Blood.txt
+++ b/Blood.txt
@@ -395,11 +395,11 @@ ACTOR BloodDripingFromCeiling: Brutal_FlyingBlood
 	{
 	Spawn:
 		TNT1 A 0
-	Live:
 		TNT1 A 0 A_Jump(230, "NoSpawn")
+	Live:
 		TNT1 A 0 A_JumpIf(waterlevel > 1, "Splash")
 		BLUD ZZZZZZZZZZZZZZZZZZZZZZZZZ 20 A_ChangeVelocity(0,0,-1)
-		loop
+		Stop
 	Death:
 		TNT1 A 0
 		TNT1 A 0 A_PlaySound("blooddrop2")
@@ -418,11 +418,11 @@ ACTOR BloodDripingFromCeilingBig: BloodDripingFromCeiling
     {
 	Spawn:
 		TNT1 A 0
-	Live:
 		TNT1 A 0 A_Jump(160, "NoSpawn")
+	Live:
 		TNT1 A 0 A_JumpIf(waterlevel > 1, "Splash")
 		BLUD ZZZZZZZZZZZZZZZZZZZZZZZZZ 20 A_ChangeVelocity(0,0,-1)
-		loop
+		Stop
 	Death:
 		TNT1 A 0
 		TNT1 A 0 A_PlaySound("blooddrop2")

--- a/Blood.txt
+++ b/Blood.txt
@@ -329,38 +329,37 @@ ACTOR Brutal_FlyingBlood
    +FORCEXYBILLBOARD
    +MOVEWITHSECTOR
    +DONTSPLASH
-    States
+	States
     {
-     Spawn:
+		Spawn:
 			TNT1 A 0
 			TNT1 A 0 A_JumpIf(waterlevel > 1, "Splash")
 			TNT1 A 0 A_Jump(255, "Spawn1", "Spawn2", "Spawn3", "Live")
-	 Spawn1:
+		Spawn1:
 			TNT1 A 0
 			TNT1 A 0 A_SetScale(-0.6, 0.6)
 			Goto live
 
-	Spawn2:
+		Spawn2:
 			TNT1 A 0
 			TNT1 A 0 A_SetScale(-0.7, -0.7)
 			Goto live
 
-	Spawn3:
+		Spawn3:
 			TNT1 A 0
 			TNT1 A 0 A_SetScale(0.6, -0.6)
 			Goto live
 
-	 Live:
+		Live:
 			BSPR ABCDEFGH 2
 			BSPR I 100 A_JumpIf(waterlevel > 1, "Splash")
 			Stop
 
-	Splash:
+		Splash:
 			BLOD A 0
 			TNT1 A 0 A_CustomMissile ("Underblood2", 7, 0, random (0, 360), 2, random (30, 150))
 			stop
-
-     Death:
+		Death:
 			TNT1 A 0
 			TNT1 A 0 A_PlaySound("blooddrop2")
 			TNT1 A 0 A_CheckFloor("DeathFloor")
@@ -371,7 +370,7 @@ ACTOR Brutal_FlyingBlood
 			TNT1 A 0
 			TNT1 A 0 A_SpawnItemEx ("Brutal_BloodSpot",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION |  SXF_TRANSFERTRANSLATION,0)
 			TNT1 A 0 A_PlaySound("blooddrop2")
-		    XDT1 EFGHIJKL 2
+			XDT1 EFGHIJKL 2
 			Stop
 
 		NoSpawn:
@@ -396,11 +395,11 @@ ACTOR BloodDripingFromCeiling: Brutal_FlyingBlood
 	{
 	Spawn:
 		TNT1 A 0
+	Live:
 		TNT1 A 0 A_Jump(230, "NoSpawn")
 		TNT1 A 0 A_JumpIf(waterlevel > 1, "Splash")
-		BLUD Z 500
+		BLUD ZZZZZZZZZZZZZZZZZZZZZZZZZ 20 A_ChangeVelocity(0,0,-1)
 		loop
-
 	Death:
 		TNT1 A 0
 		TNT1 A 0 A_PlaySound("blooddrop2")
@@ -419,10 +418,11 @@ ACTOR BloodDripingFromCeilingBig: BloodDripingFromCeiling
     {
 	Spawn:
 		TNT1 A 0
+	Live:
 		TNT1 A 0 A_Jump(160, "NoSpawn")
 		TNT1 A 0 A_JumpIf(waterlevel > 1, "Splash")
-		BLUD Z 500
-	loop
+		BLUD ZZZZZZZZZZZZZZZZZZZZZZZZZ 20 A_ChangeVelocity(0,0,-1)
+		loop
 	Death:
 		TNT1 A 0
 		TNT1 A 0 A_PlaySound("blooddrop2")
@@ -1036,27 +1036,27 @@ Actor DripingBlood: BloodDripingFromCeiling {Alpha 0.9 Scale 1.0}
 //This is the first drip spawned by the drip spawners, which leaves a small blood pool
 ACTOR DripingBloodLeavesPool: BloodDripingFromCeiling
 {
-+FORCEYBILLBOARD
-
- scale 0.3
-    States
-    {
-     Spawn:
-		TNT1 A 0
-        TNT1 A 0 A_JumpIf(waterlevel > 1, "Splash")
-        BLUD Z 4
-        loop
-	Splash:
-		BLOD A 0
-		TNT1 A 0 A_CustomMissile ("Underblood2", 7, 0, random (0, 360), 2, random (30, 150))
-		stop
-     Death:
-	    TNT1 A 0
-        TNT1 A 0 A_SpawnItem("MediumBloodSpot")
-		TNT1 A 0 A_PlaySound("blooddrop2")
-		XDT1 EFGHIJKL 2
-        Stop
-    }
+	+FORCEYBILLBOARD
+	scale 0.3
+	States
+	{
+		Spawn:
+			TNT1 A 0
+		Live:
+			TNT1 A 0 A_JumpIf(waterlevel > 1, "Splash")
+			BLUD Z 20 A_ChangeVelocity(0,0,-1)
+			loop
+		Splash:
+			BLOD A 0
+			TNT1 A 0 A_CustomMissile ("Underblood2", 7, 0, random (0, 360), 2, random (30, 150))
+			stop
+		Death:
+			TNT1 A 0
+			TNT1 A 0 A_SpawnItem("MediumBloodSpot")
+			TNT1 A 0 A_PlaySound("blooddrop2")
+			XDT1 EFGHIJKL 2
+			Stop
+	}
 }
 
 //Just like above, but leaves a smaller pool

--- a/Zombiemen.txt
+++ b/Zombiemen.txt
@@ -3347,10 +3347,7 @@ Actor DeadZombieMan_Blasted: ZombiemanTorso
 		TNT1 AA 0 A_CustomMissile ("XDeath1", 15, 0, random (0, 360), 2, random (0, 180))
 		TNT1 A 0 A_CustomMissile ("XDeathArm1", 15, 0, random (0, 360), 2, random (0, 180))
 		TNT1 A 0 A_SpawnItem("ZombiemanHeadExplode")
-		TNT1 AAAA 0 A_CustomMissile ("BloodMistBig", 15, 0, random (0, 360), 2, random (0, 60))
-		TNT1 AA 0 A_SpawnItem("MeatDeath")
-		TNT1 A 0 A_SpawnItem ("DeadZombiemanJustLegsAreLeft")
-		TNT1 A 0 A_SpawnItem ("RipGuts")
+		TNT1 A 0 A_SpawnItem ("DeadZombieman_NoHeadNoArms")
 		Stop
 		}}
 

--- a/Zombiemen.txt
+++ b/Zombiemen.txt
@@ -3336,18 +3336,21 @@ Actor DeadZombieMan_NoHeadFront: DeadZombieMan_NoArm
 	}
 }
 
-Actor DeadZombieMan_Blasted: DeadZombieMan_NoHeadFront
+Actor DeadZombieMan_Blasted: ZombiemanTorso
 {States{
 		Spawn:
         ZXZ2 E -1
         Stop
 
 		Death:
-	    TNT1 A 0 A_NoBlocking
+		TNT1 A 0 A_NoBlocking
 		TNT1 AA 0 A_CustomMissile ("XDeath1", 15, 0, random (0, 360), 2, random (0, 180))
 		TNT1 A 0 A_CustomMissile ("XDeathArm1", 15, 0, random (0, 360), 2, random (0, 180))
+		TNT1 A 0 A_SpawnItem("ZombiemanHeadExplode")
 		TNT1 AAAA 0 A_CustomMissile ("BloodMistBig", 15, 0, random (0, 360), 2, random (0, 60))
-        TNT1 A 0 A_SpawnItem ("DeadZombieman_NoHeadNoArm")
+		TNT1 AA 0 A_SpawnItem("MeatDeath")
+		TNT1 A 0 A_SpawnItem ("DeadZombiemanJustLegsAreLeft")
+		TNT1 A 0 A_SpawnItem ("RipGuts")
 		Stop
 		}}
 

--- a/Zombiemen.txt
+++ b/Zombiemen.txt
@@ -3346,7 +3346,8 @@ Actor DeadZombieMan_Blasted: ZombiemanTorso
 		TNT1 A 0 A_NoBlocking
 		TNT1 AA 0 A_CustomMissile ("XDeath1", 15, 0, random (0, 360), 2, random (0, 180))
 		TNT1 A 0 A_CustomMissile ("XDeathArm1", 15, 0, random (0, 360), 2, random (0, 180))
-		TNT1 A 0 A_SpawnItem("ZombiemanHeadExplode")
+		TNT1 AAAA 0 A_CustomMissile ("BloodMistBig", 15, 0, random (0, 360), 2, random (0, 60))
+        	TNT1 A 0 A_SpawnItem("ZombiemanHeadExplode")
 		TNT1 A 0 A_SpawnItem ("DeadZombieman_NoHeadNoArms")
 		Stop
 		}}


### PR DESCRIPTION
The weird behaviour of the ceiling blood drops, resetting their own vertical velocity, is a bit uncommon but noticeable when you explode or headshot a zombieman on the 4 lifts from the first level in Doom 2, or an enemy on any moving sector. I've been attempting to fix this for days (Then later realized it was impossible to)
Plus, I missed the bug where the blasted zombieman will regrow his remains when you gib him after he collapses