### PR TITLE
Implement SlaughterWAD Detection

### DIFF
--- a/ArchVile.txt
+++ b/ArchVile.txt
@@ -57,6 +57,10 @@ ACTOR TheArchvile: Archvile Replaces Archvile
 		DIAB B 0
 		TNT1 A 0 A_GiveInventory("EnemyIsArchvile")
 		TNT1 A 0 ACS_NamedExecuteAlways("BDCHeckClassicMonsters", 0, 0, 0, 0)//Check if Vanilla Mode is activated
+		DIAB A 2
+		TNT1 A 0 A_RadiusGive("SlaughterToken", 128, RGF_GIVESELF | RGF_MONSTERS |RGF_CUBE | RGF_NOSIGHT, 1)
+		DIAB A 2
+		TNT1 A 0 A_JumpIfInventory("SlaughterToken",9,"ReplaceVanilla")
 
 	Idle:
 	Spawn2:

--- a/Baron.txt
+++ b/Baron.txt
@@ -34,7 +34,7 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 	MaxStepHeight 24
 	MaxDropOffHeight 32
 	DeathHeight 0
-	Radius 21
+	Radius 24
 	Height 60
 	BurnHeight 0
 	Speed 6
@@ -44,7 +44,6 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 	Species "Bruiser"
 	States
 	{
-
 	ReplaceVanilla:
 		TNT1 A 0
 		TNT1 A 0 A_NoBlocking
@@ -92,6 +91,9 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 		TNT1 A 0 ACS_NamedExecuteAlways("BDCheckStuff")//Check if new monsters are disabled
 		BARO B 2
 		TNT1 A 0 A_JumpIfInventory("nonewenemies", 1, "Stand")
+		TNT1 A 0 A_RadiusGive("SlaughterToken", 128, RGF_GIVESELF | RGF_MONSTERS |RGF_CUBE | RGF_NOSIGHT, 1)
+		BARO B 2
+		TNT1 A 0 A_JumpIfInventory("SlaughterToken",9,"ReplaceVanilla")
 		TNT1 A 0 A_JumpIf(x == 304, "ReplaceForBoss1")
 		TNT1 A 0 A_JumpIf(x == 528, "ReplaceForBoss2")
 		TNT1 A 0 A_Jump(4, "ReplaceBelphegor")
@@ -124,18 +126,9 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 		TNT1 A 0 A_SpawnItem("HeadshotTarget6b", 0, 58)
 		BTS3 D 4
 		BTS3 CBA 1
-		Goto See2
+		Goto SeeContinue
 
-	See2:
-		TNT1 A 0
-		TNT1 A 0 A_JumpIfInventory("Curbstomp_Marine", 1, "CurbstompMarine")
-		TNT1 A 0 A_JumpIfInventory("ZombiemanFatality", 1, "FatalityZombieman")
-		TNT1 A 0 A_JumpIfInventory("SergeantFatality", 1, "FatalitySergeant")
-		TNT1 A 0 A_JumpIfInventory("DemonFatality", 1, "FatalityDemon")
-		TNT1 A 0 A_JumpIfInventory("ImpFatality", 1, "FatalityImp")
-		TNT1 A 0 A_JumpIfInventory("HasExplosiveBarrel", 1, "MissileBarrel")
-
-	See4:
+	SeeContinue:
 		TNT1 A 0
 		TNT1 A 0 A_SpawnItem("HeadshotTarget6b", 0, 58)
 		BARO AAA 2 A_Chase
@@ -184,11 +177,10 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 		BTS3 CBA 2  A_SpawnItem("HeadshotTarget4b", 0, 58)
 		TNT1 A 0 HealThing(200)
 		TNT1 A 0 A_Jump(96, "SpecialAttack")
-		Goto See2
+		Goto SeeContinue
 
 	Melee:
 	    TNT1 A 0
-
 	    TNT1 A 0 A_JumpIfInTargetInventory("TargetIsACyberdemon", 1, "CheckRetreat")
 		TNT1 A 0 A_JumpIfInTargetInventory("TargetIsAMastermind", 1, "CheckRetreat")
 		TNT1 A 0 A_FaceTarget
@@ -205,32 +197,18 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 		BARO G 6 A_CustomMissile("BaronAttack",32,0,0,0)
 		TNT1 A 0 A_JumpIfInventory("Curbstomp_Marine", 1, "CurbstompMarine")
 		TNT1 A 0 A_JumpIfInventory("ZombiemanFatality", 1, "FatalityZombieman")
-		Goto See2
-
-	Melee2:
-		TNT1 A 0 A_SpawnItem("HeadshotTarget6b", 0, 58)
-		BARO E 6 A_FaceTarget
-		TNT1 A 0 A_SpawnItem("HeadshotTarget6b", 0, 58)
-		BARO F 6 A_FaceTarget
-		TNT1 A 0 A_SpawnItem("HeadshotTarget6b", 0, 58)
-		BARO G 6 A_CustomMissile("BaronAttack",32,0,0,0)
-		TNT1 A 0 A_JumpIfInventory("Curbstomp_Marine", 1, "CurbstompMarine")
-		TNT1 A 0 A_JumpIfInventory("ZombiemanFatality", 1, "FatalityZombieman")
 		TNT1 A 0 A_JumpIfInventory("SergeantFatality", 1, "FatalitySergeant")
 		TNT1 A 0 A_JumpIfInventory("DemonFatality", 1, "FatalityDemon")
 		TNT1 A 0 A_JumpIfInventory("ImpFatality", 1, "FatalityImp")
-		Goto See2
+		TNT1 A 0 A_JumpIfInventory("HasExplosiveBarrel", 1, "MissileBarrel")
+		Goto SeeContinue
 
     Missile:
 		BARO A 1
 		TNT1 A 0 A_JumpIfInTargetInventory("TargetIsACyberdemon", 1, "CheckRetreat")
 		TNT1 A 0 A_JumpIfInTargetInventory("TargetIsAMastermind", 1, "CheckRetreat")
-		TNT1 A 0 A_JumpIfInTargetInventory("TargetIsAnExplosiveBarrel", 1, "See2")
+		TNT1 A 0 A_JumpIfInTargetInventory("TargetIsAnExplosiveBarrel", 1, "SeeContinue")
 		TNT1 A 0 A_TakeInventory("StopKickingMyBallsMotherFucker", 1)
-		TNT1 A 0 A_JumpIfInventory("Curbstomp_Marine", 1, "CurbstompMarine")
-		TNT1 A 0 A_JumpIfInventory("ZombiemanFatality", 1, "FatalityZombieman")
-		TNT1 A 0 A_JumpIfInTargetInventory ("TypeZombieman", 1, "See2")
-		TNT1 A 0 A_JumpIfInTargetInventory ("TypeSergeant", 1, "See2")
 		TNT1 A 0 A_SpawnItem("HeadshotTarget4b", 0, 58)
 		BARO E 3 A_FaceTarget
 
@@ -262,7 +240,7 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 		BARO G 8 A_CustomMissile("GreenPlasmaBall", 36, 0, 0, 1)
 		TNT1 A 0 A_CustomMissile("Alerter", 36)
 		TNT1 A 0 A_TakeInventory("ComingToGetTheBarrel", 1)
-		Goto See2
+		Goto SeeContinue
 
     SpecialAttack:
 	    TNT1 A 0 A_SpawnItem("HeadshotTarget4b", 0, 58)
@@ -312,7 +290,7 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 		BARO R 8 A_CustomMissile("GreenPlasmaBall", 36, 0, 0, 11)
 		TNT1 A 0 A_CustomMissile("Alerter", 36)
 		TNT1 A 0 A_TakeInventory("ComingToGetTheBarrel", 1)
-		Goto See2
+		Goto SeeContinue
 
 	CheckRetreat:
 		TNT1 A 0
@@ -321,7 +299,6 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 
 	Retreat:
 		TNT1 A 0
-        //TNT1 A 0 A_SpawnItemEx("FootSep", 0, 0)
 		TNT1 A 0 A_FaceTarget
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 58)
 		BARO DD 2 A_Recoil(2)
@@ -347,7 +324,7 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 		TNT1 A 0
 		TNT1 A 0 A_GiveInventory("ComingToGetTheBarrel", 1)
 		TNT1 A 0
-		Goto See2
+		Goto SeeContinue
 
 	MissileBarrel:
 		BOBA A 0
@@ -384,7 +361,7 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 		TNT1 A 0 A_TakeInventory("ComingToGetTheBarrel", 1)
 		TNT1 A 0 A_TakeInventory("HasExplosiveBarrel", 1)
 		BOBA A 0 A_ChangeFlag("NOPAIN", 0)
-		Goto See2
+		Goto SeeContinue
 
 	Pain:
 		TNT1 A 0 A_JumpIfInventory("Curbstomp_Marine", 1, "CurbstompMarine")
@@ -392,7 +369,7 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 		BARO H  3
 		TNT1 A 0 A_SpawnItem("HeadshotTarget4b", 0, 58)
 		BARO H  3 A_Pain
-		Goto See2
+		Goto SeeContinue
 
 	Pain.Explosive:
 		TNT1 A 0
@@ -440,6 +417,7 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 
 	Death.Desintegrate:
 	Death.Saw:
+		TNT1 A 0
 		TNT1 A 0 A_Scream
 		TNT1 A 0 A_Stop
         TNT1 A 0 A_NoBlocking
@@ -468,7 +446,7 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 		TNT1 A 0 A_SpawnItem("HeadshotTarget4b", 0, 58)
 		BARO H 3 A_Pain
 		TNT1 A 0 A_ChangeFLag("NOPAIN", 0)
-		Goto See2
+		Goto SeeContinue
 
 	Pain.Kick:
 	    TNT1 A 0
@@ -711,7 +689,7 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
         TNT1 A 0 A_TakeInventory("Curbstomp_Marine",1)
         TNT1 A 0 A_ChangeFlag("NOPAIN", 0)
 		TNT1 A 0 A_SpawnItem ("RappedMarine", 1)
-		Goto See2
+		Goto SeeContinue
 
    FatalityZombieman:
         TNT1 A 0 A_ChangeFlag("NOPAIN", 1)
@@ -738,7 +716,7 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 		BARO F 4 A_CustomMissile("ThrowedZombieMan2", 64, 0, 0, 0)
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 58)
 		BARO G 4
-		Goto See2
+		Goto SeeContinue
 
 	FatalitySergeant:
         TNT1 A 0 A_ChangeFlag("NOPAIN", 1)
@@ -767,7 +745,7 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 		BARO F 4 A_CustomMissile("ThrowedSergeantPiece", 64, 0, 0, 0)
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 58)
 		BARO G 4
-        Goto See2
+        Goto SeeContinue
 
        FatalityDemon:
         TNT1 A 0 A_ChangeFlag("NOPAIN", 1)
@@ -786,7 +764,7 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 
         TNT1 A 0 A_TakeInventory("DemonFatality",1)
         TNT1 A 0 A_ChangeFlag("NOPAIN", 0)
-        Goto See2
+        Goto SeeContinue
 
 	FatalityImp:
         TNT1 A 0 A_ChangeFlag("NOPAIN", 1)
@@ -805,7 +783,7 @@ ACTOR BaronofHell2 : BaronofHell Replaces BaronofHell
 	   TNT1 A 0 A_SpawnItem("DeadImp_BaronFatality")
         TNT1 A 0 A_TakeInventory("ImpFatality",1)
         TNT1 A 0 A_ChangeFlag("NOPAIN", 0)
-        Goto See2
+        Goto SeeContinue
 	}
 }
 
@@ -1253,11 +1231,6 @@ Actor BaronBoss1: BaronofHell2 3013
 		TNT1 A 0 ACS_NamedExecuteAlways("BDBruiserBrothersHealth")
 		TNT1 A 0 ACS_NamedExecuteAlways("BDBruiserBrotherOne")
 		TNT1 A 0 A_changeFlag("MISSILEMORE", 1)
-		TNT1 A 0 A_JumpIfInventory("Curbstomp_Marine", 1, "CurbstompMarine")
-		TNT1 A 0 A_JumpIfInventory("ZombiemanFatality", 1, "FatalityZombieman")
-		TNT1 A 0 A_JumpIfInventory("SergeantFatality", 1, "FatalitySergeant")
-		TNT1 A 0 A_JumpIfInventory("ImpFatality", 1, "FatalityImp")
-		TNT1 A 0 A_JumpIfInventory("DemonFatality", 1, "FatalityDemon")
 		TNT1 A 0 A_JumpIfInventory("HasExplosiveBarrel", 1, "MissileBarrel")
 	    TNT1 A 0 A_SpawnItem("HeadshotTarget4b", 0, 72)
 		BARO A 1
@@ -1266,18 +1239,9 @@ Actor BaronBoss1: BaronofHell2 3013
 		TNT1 A 0 A_SpawnItem("HeadshotTarget6b", 0, 72)
 		BTS3 D 4
 		BTS3 CBA 1
-		Goto See2
+		Goto SeeContinue
 
-	See2:
-		TNT1 A 0
-		TNT1 A 0 A_JumpIfInventory("Curbstomp_Marine", 1, "CurbstompMarine")
-		TNT1 A 0 A_JumpIfInventory("ZombiemanFatality", 1, "FatalityZombieman")
-		TNT1 A 0 A_JumpIfInventory("SergeantFatality", 1, "FatalitySergeant")
-		TNT1 A 0 A_JumpIfInventory("DemonFatality", 1, "FatalityDemon")
-		TNT1 A 0 A_JumpIfInventory("ImpFatality", 1, "FatalityImp")
-		TNT1 A 0 A_JumpIfInventory("HasExplosiveBarrel", 1, "MissileBarrel")
-
-	See4:
+	SeeContinue:
 		TNT1 A 0
 		TNT1 A 0 A_SpawnItem("HeadshotTarget6b", 0, 72)
 		BARO AAA 2 A_Chase
@@ -1326,7 +1290,7 @@ Actor BaronBoss1: BaronofHell2 3013
 		BTS3 CBA 2  A_SpawnItem("HeadshotTarget4b", 0, 72)
 		TNT1 A 0 HealThing(200)
 		TNT1 A 0 A_Jump(96, "SpecialAttack")
-		Goto See2
+		Goto SeeContinue
 
 	Melee:
 	    TNT1 A 0
@@ -1346,32 +1310,18 @@ Actor BaronBoss1: BaronofHell2 3013
 		BARO G 6 A_CustomMissile("BaronAttack",32,0,0,0)
 		TNT1 A 0 A_JumpIfInventory("Curbstomp_Marine", 1, "CurbstompMarine")
 		TNT1 A 0 A_JumpIfInventory("ZombiemanFatality", 1, "FatalityZombieman")
-		Goto See2
-
-	Melee2:
-		TNT1 A 0 A_SpawnItem("HeadshotTarget6b", 0, 72)
-		BARO E 6 A_FaceTarget
-		TNT1 A 0 A_SpawnItem("HeadshotTarget6b", 0, 72)
-		BARO F 6 A_FaceTarget
-		TNT1 A 0 A_SpawnItem("HeadshotTarget6b", 0, 72)
-		BARO G 6 A_CustomMissile("BaronAttack",32,0,0,0)
-		TNT1 A 0 A_JumpIfInventory("Curbstomp_Marine", 1, "CurbstompMarine")
-		TNT1 A 0 A_JumpIfInventory("ZombiemanFatality", 1, "FatalityZombieman")
 		TNT1 A 0 A_JumpIfInventory("SergeantFatality", 1, "FatalitySergeant")
 		TNT1 A 0 A_JumpIfInventory("DemonFatality", 1, "FatalityDemon")
 		TNT1 A 0 A_JumpIfInventory("ImpFatality", 1, "FatalityImp")
-		Goto See2
+		TNT1 A 0 A_JumpIfInventory("HasExplosiveBarrel", 1, "MissileBarrel")
+		Goto SeeContinue
 
     Missile:
 		BARO A 1
 		TNT1 A 0 A_JumpIfInTargetInventory("TargetIsACyberdemon", 1, "CheckRetreat")
 		TNT1 A 0 A_JumpIfInTargetInventory("TargetIsAMastermind", 1, "CheckRetreat")
-		TNT1 A 0 A_JumpIfInTargetInventory("TargetIsAnExplosiveBarrel", 1, "See2")
+		TNT1 A 0 A_JumpIfInTargetInventory("TargetIsAnExplosiveBarrel", 1, "SeeContinue")
 		TNT1 A 0 A_TakeInventory("StopKickingMyBallsMotherFucker", 1)
-		TNT1 A 0 A_JumpIfInventory("Curbstomp_Marine", 1, "CurbstompMarine")
-		TNT1 A 0 A_JumpIfInventory("ZombiemanFatality", 1, "FatalityZombieman")
-		TNT1 A 0 A_JumpIfInTargetInventory ("TypeZombieman", 1, "See2")
-		TNT1 A 0 A_JumpIfInTargetInventory ("TypeSergeant", 1, "See2")
 		TNT1 A 0 A_SpawnItem("HeadshotTarget4b", 0, 72)
 		BARO E 3 A_FaceTarget
 
@@ -1403,7 +1353,7 @@ Actor BaronBoss1: BaronofHell2 3013
 		BARO G 8 A_CustomMissile("GreenPlasmaBall", 36, 0, 0, 1)
 		TNT1 A 0 A_CustomMissile("Alerter", 36)
 		TNT1 A 0 A_TakeInventory("ComingToGetTheBarrel", 1)
-		Goto See2
+		Goto SeeContinue
 
     SpecialAttack:
 	    TNT1 A 0 A_SpawnItem("HeadshotTarget4b", 0, 72)
@@ -1452,7 +1402,7 @@ Actor BaronBoss1: BaronofHell2 3013
 		BARO R 8 A_CustomMissile("GreenPlasmaBall", 36, 15, 0, 11)
 		TNT1 A 0 A_CustomMissile("Alerter", 36)
 		TNT1 A 0 A_TakeInventory("ComingToGetTheBarrel", 1)
-		Goto See2
+		Goto SeeContinue
 
 	CheckRetreat:
 		TNT1 A 0
@@ -1461,7 +1411,6 @@ Actor BaronBoss1: BaronofHell2 3013
 
 	Retreat:
 		TNT1 A 0
-        //TNT1 A 0 A_SpawnItemEx("FootSep", 0, 0)
 		TNT1 A 0 A_FaceTarget
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 72)
 		BARO DD 2 A_Recoil(2)
@@ -1488,7 +1437,7 @@ Actor BaronBoss1: BaronofHell2 3013
 		TNT1 A 0 HealThing(1)
 		TNT1 A 0 A_GiveInventory("ComingToGetTheBarrel", 1)
 		TNT1 A 0
-		Goto See2
+		Goto SeeContinue
 
 	MissileBarrel:
 		BOBA A 0
@@ -1525,7 +1474,7 @@ Actor BaronBoss1: BaronofHell2 3013
 		TNT1 A 0 A_TakeInventory("ComingToGetTheBarrel", 1)
 		TNT1 A 0 A_TakeInventory("HasExplosiveBarrel", 1)
 		BOBA A 0 A_ChangeFlag("NOPAIN", 0)
-		Goto See2
+		Goto SeeContinue
 
 	Pain:
 		TNT1 A 0 A_JumpIfInventory("Curbstomp_Marine", 1, "CurbstompMarine")
@@ -1533,7 +1482,7 @@ Actor BaronBoss1: BaronofHell2 3013
 		BARO H  3
 		TNT1 A 0 A_SpawnItem("HeadshotTarget4b", 0, 72)
 		BARO H  3 A_Pain
-		Goto See2
+		Goto SeeContinue
 
 	Pain.Explosive:
 		TNT1 A 0
@@ -1609,7 +1558,7 @@ Actor BaronBoss1: BaronofHell2 3013
 		TNT1 A 0 A_SpawnItem("HeadshotTarget4b", 0, 72)
 		BARO H 3 A_Pain
 		TNT1 A 0 A_ChangeFLag("NOPAIN", 0)
-		Goto See2
+		Goto SeeContinue
 
 	Pain.Kick:
 	    TNT1 A 0
@@ -1854,7 +1803,7 @@ Actor BaronBoss1: BaronofHell2 3013
         TNT1 A 0 A_TakeInventory("Curbstomp_Marine",1)
         TNT1 A 0 A_ChangeFlag("NOPAIN", 0)
 		TNT1 A 0 A_SpawnItem ("RappedMarine", 1)
-		Goto See2
+		Goto SeeContinue
 
    FatalityZombieman:
         TNT1 A 0 A_ChangeFlag("NOPAIN", 1)
@@ -1881,7 +1830,7 @@ Actor BaronBoss1: BaronofHell2 3013
 		BARO F 4 A_CustomMissile("ThrowedZombieMan2", 64, 0, 0, 0)
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 72)
 		BARO G 4
-		Goto See2
+		Goto SeeContinue
 
 	FatalitySergeant:
         TNT1 A 0 A_ChangeFlag("NOPAIN", 1)
@@ -1910,7 +1859,7 @@ Actor BaronBoss1: BaronofHell2 3013
 		BARO F 4 A_CustomMissile("ThrowedSergeantPiece", 64, 0, 0, 0)
 		TNT1 A 0 A_SpawnItem("HeadshotTarget8b", 0, 72)
 		BARO G 4
-        Goto See2
+        Goto SeeContinue
 
        FatalityDemon:
         TNT1 A 0 A_ChangeFlag("NOPAIN", 1)
@@ -1929,7 +1878,7 @@ Actor BaronBoss1: BaronofHell2 3013
 
         TNT1 A 0 A_TakeInventory("DemonFatality",1)
         TNT1 A 0 A_ChangeFlag("NOPAIN", 0)
-        Goto See2
+        Goto SeeContinue
 
 	FatalityImp:
         TNT1 A 0 A_ChangeFlag("NOPAIN", 1)
@@ -1948,7 +1897,7 @@ Actor BaronBoss1: BaronofHell2 3013
 	   TNT1 A 0 A_SpawnItem("DeadImp_BaronFatality")
         TNT1 A 0 A_TakeInventory("ImpFatality",1)
         TNT1 A 0 A_ChangeFlag("NOPAIN", 0)
-        Goto See2
+        Goto SeeContinue
 		}
 }
 
@@ -1984,6 +1933,6 @@ States
 		TNT1 A 0 A_SpawnItem("HeadshotTarget6b", 0, 72)
 		BTS3 D 4
 		BTS3 CBA 1
-		Goto See2
+		Goto SeeContinue
 	}
 }

--- a/Cacodemo.txt
+++ b/Cacodemo.txt
@@ -5,7 +5,7 @@ ACTOR Cacodemon_ : Cacodemon Replaces Cacodemon
 	bloodcolor "Blue"
 	SpawnID 19
     GibHealth 25
-	Radius 28
+	Radius 31
 	Height 56
 	Mass 400
 	Speed 9
@@ -67,7 +67,10 @@ ACTOR Cacodemon_ : Cacodemon Replaces Cacodemon
     Spawn:
 		HEAD A 0
 		TNT1 A 0 ACS_NamedExecuteAlways("BDCHeckClassicMonsters", 0, 0, 0, 0)//Check if Vanilla Mode is activated
-		HEAD A 10 A_Look
+		HEAD A 2
+		TNT1 A 0 A_RadiusGive("SlaughterToken", 192, RGF_GIVESELF | RGF_MONSTERS |RGF_CUBE | RGF_NOSIGHT, 1)
+		HEAD A 2
+		TNT1 A 0 A_JumpIfInventory("SlaughterToken",9,"ReplaceVanilla")
 		TNT1 A 0 A_JumpIfInventory("Curbstomp_Marine", 1, "FatalityMarine")
 		Goto Stand
 
@@ -266,7 +269,6 @@ ACTOR Cacodemon_ : Cacodemon Replaces Cacodemon
 		TNT1 A 0 A_JumpIf(momz == 0, "FallAndBurn")
 
 	FallAndBurn:
-
 		TNT1 A 0 A_SpawnItemEx ("DetectFloorCraterSmall",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION,0)
 		TNT1 A 0 A_SpawnItem("BarrelExplosionSmokeColumn")
 		TNT1 AA 0 A_SpawnItemEx("TinyBurningPiece", random (-15, 15), random (-15, 15))
@@ -288,6 +290,7 @@ ACTOR Cacodemon_ : Cacodemon Replaces Cacodemon
 	Death.Explosive:
 	XDeath:
 	Death.Desintegrate:
+		TNT1 A 0
 		TNT1 A 0 A_XScream
 		TNT1 A 0 A_NoBlocking
         TNT1 A 0 A_CustomMissile ("CacoXDeath", 0, 0, random (0, 360), 2, random (0, 160))
@@ -370,7 +373,6 @@ Death.Ice:
 
 Death.Massacre:
 	Goto Death
-
 	}
 }
 

--- a/Comando.txt
+++ b/Comando.txt
@@ -1,7 +1,7 @@
 ACTOR ChaingunGuy1: ChaingunGuy Replaces ChaingunGuy
 {
 	Health 80
-	Radius 16
+	Radius 20
 	Height 49
 	Mass 100
 	Speed 5
@@ -21,7 +21,6 @@ ACTOR ChaingunGuy1: ChaingunGuy Replaces ChaingunGuy
 
 	Damagetype "Melee"
 	Monster
-	//Translation "192:207=176:191"
 	MaxStepHeight 24
 	MaxDropOffHeight 32
 	+FLOORCLIP
@@ -41,7 +40,6 @@ ACTOR ChaingunGuy1: ChaingunGuy Replaces ChaingunGuy
 	DropItem "DropedChaingunSpawner"
 	Obituary "%o has been mowed down by a Zombie Commando."
 	Tag "Minigun Zombie"
-
 	States
 	{
 	ReplaceVanilla:
@@ -50,9 +48,12 @@ ACTOR ChaingunGuy1: ChaingunGuy Replaces ChaingunGuy
 		TNT1 A 0 A_SpawnItemEx ("VanillaChaingunguy",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION | SXF_TRANSFERAMBUSHFLAG ,0)
 		Stop
     Spawn:
-		MPOS A 1
+		MPOS A 0
 		MPOS A 0 ACS_NamedExecuteAlways("BDCHeckClassicMonsters", 0, 0, 0, 0)//Check if Vanilla Mode is activated
 		MPOS A 2
+		TNT1 A 0 A_RadiusGive("SlaughterToken", 128, RGF_GIVESELF | RGF_MONSTERS |RGF_CUBE | RGF_NOSIGHT, 1)
+		MPOS A 2
+		TNT1 A 0 A_JumpIfInventory("SlaughterToken",9,"ReplaceVanilla")
 		MPOS A 0 A_GiveInventory("SKChaingunGuy", 1)
 		MPOS A 0 A_JumpIfInTargetInventory("ChainguyguyContinue", 1, "MissileContinue")
 		Goto Stand
@@ -507,21 +508,20 @@ ACTOR ChaingunGuy1: ChaingunGuy Replaces ChaingunGuy
 	Death.Explosive:
 	Death.Landmine:
 	Death.LandMine2:
-	TNT1 A 0
-	TNT1 A 0
-	TNT1 A 0 ThrustThingZ(0,40,0,1)
-	TNT1 A 0 A_SpawnItemEx("MuchBlood2", 0, 0, 40)
-	TNT1 AA 0 A_CustomMissile ("XDeath1", 40, 0, random (0, 360), 2, random (0, 160))
-	TNT1 AA 0 A_CustomMissile ("SuperWallRedBlood", 46, 0, random (170, 190), 2, random (0, 40))
-	TNT1 AAAAAA 0 A_CustomMissile ("BloodMistLarge", 40, 0, random (0, 360), 2, random (20, 90))
-	TNT1 A 0 A_CustomMissile ("XDeathChainArm", 62, 0, random (0, 360), 2, random (0, 160))
-	TNT1 A 0 A_CustomMissile ("XDeathChainLeg", 32, 0, random (0, 360), 2, random (0, 160))
-	TNT1 AA 0 A_CustomMissile ("XDeath1", 40, 0, random (0, 360), 2, random (0, 160))
-	TNT1 AAAAAA 0 A_CustomMissile ("BloodMistLarge", 40, 0, random (0, 360), 2, random (20, 90))
-	TNT1 AAAAAAAAAAA 0 A_CustomMissile ("BrainBlood", 50, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0
+		TNT1 A 0 ThrustThingZ(0,40,0,1)
+		TNT1 A 0 A_SpawnItemEx("MuchBlood2", 0, 0, 40)
+		TNT1 AA 0 A_CustomMissile ("XDeath1", 40, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AA 0 A_CustomMissile ("SuperWallRedBlood", 46, 0, random (170, 190), 2, random (0, 40))
+		TNT1 AAAAAA 0 A_CustomMissile ("BloodMistLarge", 40, 0, random (0, 360), 2, random (20, 90))
+		TNT1 A 0 A_CustomMissile ("XDeathChainArm", 62, 0, random (0, 360), 2, random (0, 160))
+		TNT1 A 0 A_CustomMissile ("XDeathChainLeg", 32, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AA 0 A_CustomMissile ("XDeath1", 40, 0, random (0, 360), 2, random (0, 160))
+		TNT1 AAAAAA 0 A_CustomMissile ("BloodMistLarge", 40, 0, random (0, 360), 2, random (20, 90))
+		TNT1 AAAAAAAAAAA 0 A_CustomMissile ("BrainBlood", 50, 0, random (0, 360), 2, random (0, 160))
 
-	    CPDE A 1 A_Scream
-	    CPDE A 1 A_NoBlocking
+		CPDE A 1 A_Scream
+		CPDE A 1 A_NoBlocking
 		TNT1 A 0 A_GiveToTarget("SoulAmmo", 10)
 		CPDE A 2 A_CheckFloor ("Dead.Landmine")
 		CPDE BCDEFGH 2 A_CheckFloor ("Dead.Landmine")
@@ -585,7 +585,7 @@ ACTOR ChaingunGuy1: ChaingunGuy Replaces ChaingunGuy
         TNT1 A 0
         Stop
 
-			Death.GreenFire:
+	Death.GreenFire:
         TNT1 A 0
         TNT1 A 0 A_XScream
         TNT1 A 0 A_NoBlocking
@@ -617,6 +617,7 @@ ACTOR ChaingunGuy1: ChaingunGuy Replaces ChaingunGuy
 		Goto Death
 
 	Death.Desintegrate:
+		TNT1 A 0
         TNT1 A 0 A_XScream
         TNT1 A 0 A_NoBlocking
 		TNT1 A 0 A_GiveToTarget("SoulAmmo", 10)

--- a/Cyberdemon.txt
+++ b/Cyberdemon.txt
@@ -76,6 +76,7 @@ ACTOR TheCyberdemon: Cyberdemon Replaces Cyberdemon
 		CYBR C 1
 		TNT1 A 0 A_GiveInventory("TargetIsACyberdemon")
 		TNT1 A 0 ACS_NamedExecuteAlways("BDCHeckClassicMonsters", 0, 0, 0, 0)//Check if Vanilla Mode is activated
+		CYBR A 2
 		TNT1 A 0 A_JumpIf(x == -1472, "ReplaceForBOSS")
 		TNT1 A 0 A_SpawnItem("CybersHitBox", 0, 96)
 

--- a/Demons.txt
+++ b/Demons.txt
@@ -4,7 +4,7 @@ ACTOR BullDemon: Demon Replaces Demon
 	Health 200
     Scale 1.1
 	Height 56
-	Radius 20
+	Radius 30
 	Mass 400
     Speed 12
     FastSpeed 18
@@ -43,9 +43,12 @@ ACTOR BullDemon: Demon Replaces Demon
 		TNT1 A 0 A_SpawnItemEx ("VanillaDemon",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION | SXF_TRANSFERAMBUSHFLAG ,0)
 		Stop
     Spawn:
-		SARG Y 1
+		SARG Y 0
 		TNT1 A 0 ACS_NamedExecuteAlways("BDCHeckClassicMonsters", 0, 0, 0, 0)//Check if Vanilla Mode is activated
 		SARG Y 2
+		TNT1 A 0 A_RadiusGive("SlaughterToken", 192, RGF_GIVESELF | RGF_MONSTERS |RGF_CUBE | RGF_NOSIGHT, 1)
+		SARG Y 2
+		TNT1 A 0 A_JumpIfInventory("SlaughterToken",9,"ReplaceVanilla")
 
 	Idle:
 	Spawned:
@@ -495,6 +498,7 @@ ACTOR BullDemon: Demon Replaces Demon
 		Stop
 
 	Death.Desintegrate:
+		TNT1 A 0
 	    TNT1 A 0 A_XScream
 		TNT1 A 0 A_NoBlocking
 		TNT1 A 0 A_FaceTarget
@@ -516,6 +520,7 @@ ACTOR BullDemon: Demon Replaces Demon
 
 	XDeath:
 	DEath.Explosive:
+		TNT1 A 0
 	    TNT1 A 0 A_XScream
 		TNT1 A 0 A_NoBlocking
 		TNT1 A 0 A_FaceTarget
@@ -603,7 +608,7 @@ ACTOR BullDemon: Demon Replaces Demon
     Death.KillMe:
     Death.Taunt:
 		Goto Death
-		
+
     FatalityZombieman:
 		TNT1 A 0 A_ChangeFlag("NOPAIN", 1)
         SARK DEDEDEDEDE 8 A_CustomMissile ("MuchBlood2", 45, 0, random (0, 360), 2, random (0, 160))
@@ -753,7 +758,6 @@ ACTOR BullDemon: Demon Replaces Demon
 
 	Death.Massacre:
 	Goto Death
-
 	}
 }
 
@@ -820,7 +824,7 @@ States
 		TNT1 A 0 A_Recoil(5)
 		TNT1 A 0 ThrustThingZ(0,20,0,1)
 		Goto CleanDeath
-			
+
 	Death.SSG:
 	Death.Railgun:
 		TNT1 A 0
@@ -905,7 +909,7 @@ States
 		TNT1 A 0 A_Jump(128, "Death.Strong2")
 		TNT1 A 0 A_SpawnItem("MuchBlood", 0, 32)
 		Goto Death
-		
+
 	Death.Desintegrate:
 	Death.RVFT:
 	Death.BHFT:
@@ -970,7 +974,7 @@ States
 	    TNT1 A 0 A_ChangeFlag("SOLID", 0)
         TNT1 A 0 A_SpawnItem("ArmlessDemon")
         Stop
-		
+
 	Death.Strong:
 	Death.Strong2:
 	Death.Fatality:
@@ -993,7 +997,7 @@ States
 		SAAR I 0 A_SpawnItem("DeadDemonSAARI")
 		TNT1 A -1
         Stop
-		
+
 	Death.Melee:
 	Death.Minor:
 	CleanDeath:

--- a/ExpansionChangelog.txt
+++ b/ExpansionChangelog.txt
@@ -10,6 +10,8 @@
 //	SPRITES/VEHICLES folder:		Created rotations for TKFLA sprite
 //	All Files:						Adjusted Radius_Quake values to make things less ridiculous like the Mastermind
 //	All Meatshield actors:			Removed +THRUSPECIES and Species "Marines"
+//	All Monster files:				Implemented a slaughterwad detection system like Mark has planned for v22 (I asked if ok to do this beforehand)
+//	Baron.txt:						Removed the See2 state, Changed See4 to SeeContinue and moved fatality checks to end of Melee state
 //	Bike.txt:						Added +NOTELEPORT to the playerclass
 //	Cyberdemon.txt:					Added a check to forget target if cyberdemon is trying to stomp another cyberdemon
 //	EnemyTanks.txt:					Removed +NOTIMEFREEZE flag from actors
@@ -17,16 +19,24 @@
 //									Change the TankFireEffect to behave like the PlayerMuzzle flashes
 //	FlameCannon.txt:				Added +NOINTERACTION to all fake weapon sprite actors
 //	GLDEFS.txt:						Added dynamic light to TankFireEffect
+//									Added vanilla light defintions to VanillaLostSoul actor
 //	Grenades.txt:					PR#426 Create NoAmmo states for grenade weapon
 //	Imps.txt:						Raised height of the body hitbox to that of the sprite's shoulders
 //	LABGUY.txt:						PR#428 A little detail for Zombie Scientists
+//	LostSoul.txt:					Now can spawn a VanillaLostSoul if classicmonsters is enabled
 //	Machinegun.txt:					PR#427 allow executions in noammo or unloaded states
+//	Mancubus.txt:					Now can spawn a VanillaFatso if classicmonsters is enabled
 //	Minigun.txt:					PR#427 allow executions in noammo or unloaded states
 //	MP40.txt:						PR#427 allow executions in noammo or unloaded states
 //	NukeLauncher.txt:				Added +NOINTERACTION to all fake weapon sprite actors
+//	PainElemental.txt:				Now can spawn a VanillaPainElemental that spawns VanillaLostSouls if classicmonsters is enabled
 //	Player.txt:						Added a headkicker spawn to the end of each See state so that it is spawned every 6 tics
 //	Railgun.txt:					PR#427 allow executions in noammo or unloaded states
+//	Spiders.txt:					Now can spawn a VanillaArachnotron if classicmonsters is enabled
 //	Tank.txt:						Added +NOTELEPORT to the playerclass
+//	Tokens.txt:						Removed TypeSergeant and Zombieman tokens
+//									Created a "SlaughterToken" actor
+//	VanillaMonsters.txt:			Created Vanilla Arachnotron, PainElemental, and LostSoul actors
 //	WeaponSpawners.txt:				Removed +NOINTERACTION from BasicWeaponPickup
 //									Added +NOINTERACTION to all fake weapon sprite actors
 //	Zombieman.txt:					PR#429 Fixing another imperfection

--- a/FIREWORKS.txt
+++ b/FIREWORKS.txt
@@ -47,13 +47,13 @@ ACTOR ExplosiveBarrel1 Replaces ExplosiveBarrel
 		Stop
 
 	Spawn:
-		TNT1 A 0
+		BARI A 0
 		TNT1 A 0 A_GiveInventory("TargetIsANExplosiveBarrel", 1)
-		TNT1 A 0 A_RadiusGive("BarrelCounter",40,RGF_GIVESELF | RGF_OBJECTS | RGF_CUBE | RGF_NOSIGHT,1)
+		MARN A 0 ACS_NamedExecuteAlways("BDCheckDecorations", 0, 0, 0, 0)//Check if advanced decorations are disabled.
+		BARI A 2
+		TNT1 A 0 A_RadiusGive("BarrelCounter",64,RGF_GIVESELF | RGF_OBJECTS | RGF_CUBE | RGF_NOSIGHT,1)
 		BARI A 2
 		TNT1 A 0 A_JumpIfInventory("BarrelCounter",9,"Vanilla")
-		BARI A 2
-		MARN A 0 ACS_NamedExecuteAlways("BDCheckDecorations", 0, 0, 0, 0)//Check if advanced decorations are disabled.
 
 	Stay:
 	    BARI ABCDCB 6 A_Look
@@ -143,12 +143,13 @@ ACTOR ExplosiveBarrel1 Replaces ExplosiveBarrel
 		Wait
 
 	VanillaDeath:
-		BEXP B 4 BRIGHT A_Scream
-		BEXP C 4 BRIGHT
-		BEXP D 4 BRIGHT A_Explode(200,200)
-		BEXP E 4 BRIGHT
-		TNT1 A 840 BRIGHT A_BarrelDestroy
-		TNT1 A 4 A_Respawn
+		BEXP A 5 BRIGHT
+		BEXP B 5 BRIGHT A_Scream
+		BEXP C 5 BRIGHT
+		BEXP D 5 BRIGHT A_Explode
+		BEXP E 10 BRIGHT
+		TNT1 A 1050 BRIGHT A_BarrelDestroy
+		TNT1 A 5 A_Respawn
 		Wait
 
 	Death.Fatality:

--- a/GLDEFS.txt
+++ b/GLDEFS.txt
@@ -1315,6 +1315,22 @@ object VanillaChaingunGuy
     frame CPOSF { light ZOMBIEATK }
 }
 
+object VanillaLostSoul
+{
+    frame SKULA { light LOSTSOUL    }
+    frame SKULB { light LOSTSOUL    }
+    frame SKULC { light LOSTSOUL    }
+    frame SKULD { light LOSTSOUL    }
+    frame SKULE { light LOSTSOUL    }
+    frame SKULF { light LOSTSOUL    }
+    frame SKULG { light LOSTSOUL    }
+
+    frame SKULH { light LOSTSOUL_X1 }
+    frame SKULI { light LOSTSOUL_X2 }
+    frame SKULJ { light LOSTSOUL_X3 }
+    frame SKULK { light LOSTSOUL_X4 }
+}
+
 object VanillaShotgunGuy
 {
     frame SPOSF { light ZOMBIEATK }

--- a/Imps.txt
+++ b/Imps.txt
@@ -4,7 +4,7 @@ ACTOR Imp Replaces DoomImp
     Scale 1.04
 	SpawnID 5
 	Health 80
-	Radius 19
+	Radius 20
 	Height 45
 	Mass 100
     GibHealth 35
@@ -61,10 +61,12 @@ ACTOR Imp Replaces DoomImp
 		TNT1 A 0 A_SpawnItemEx ("VanillaImp",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION | SXF_TRANSFERAMBUSHFLAG ,0)
 		Stop
     Spawn:
-		TROS A 1
+		TROS A 0
 		TNT1 A 0 ACS_NamedExecuteAlways("BDCHeckClassicMonsters", 0, 0, 0, 0)//Check if Vanilla Mode is activated
 		TROS A 2
-		TNT1 A 0 //ACS_NamedExecuteAlways("CeilingClimbingImps", 0)//Check for CVARs
+		TNT1 A 0 A_RadiusGive("SlaughterToken", 128, RGF_GIVESELF | RGF_MONSTERS |RGF_CUBE | RGF_NOSIGHT, 1)
+		TROS A 2
+		TNT1 A 0 A_JumpIfInventory("SlaughterToken",9,"ReplaceVanilla")
 		TNT1 A 0 A_GiveInventory("SKImp", 1)
         TNT1 A 0 A_JumpIfInventory("Fatality_Marine", 1, "FatalityMarine")
 		Goto Stand
@@ -773,13 +775,14 @@ ACTOR Imp Replaces DoomImp
 		Stop
 
 	Death.Desintegrate:
+		TNT1 A 0
         TNT1 A 0 A_XScream
         TNT1 A 0 A_NoBlocking
         TNT1 A 0 A_SpawnItem("DesintegratedHuman")
 		TNT1 A 0 A_Stop
 		TGIB ABCDEFGHIJKLMNOPQ 3
 		TGIB Q -1
-      Stop
+		Stop
 
 	Death.cut:
 
@@ -958,6 +961,7 @@ DeathNoGuts:
         Stop
 
 	XDeath:
+		TNT1 A 0
 		TNT1 A 0 A_XScream
 		TNT1 A 0 A_NoBlocking
 		TNT1 AAA 0 A_CustomMissile ("XDeath1", 42, 0, random (0, 190), 2, random (10, 60))
@@ -1152,7 +1156,6 @@ DeathNoGuts:
 
 	Death.Massacre:
 	Goto Death
-
 	}
 }
 

--- a/Knight.txt
+++ b/Knight.txt
@@ -31,7 +31,7 @@ ACTOR HellKnight2 : HellKnight Replaces HellKnight
 	DeathHeight 0
 	BurnHeight 0
 	Height 54
-	Radius 19
+	Radius 24
     GibHealth 30
 	-BOSSDEATH
 	MaxStepHeight 24
@@ -114,6 +114,10 @@ ACTOR HellKnight2 : HellKnight Replaces HellKnight
 		BOS2 B 0
 		TNT1 A 0 A_GiveInventory("TargetIsABaronOfHell")
 		TNT1 A 0 ACS_NamedExecuteAlways("BDCHeckClassicMonsters", 0, 0, 0, 0)//Check if Vanilla Mode is activated
+		BOS2 B 2
+		TNT1 A 0 A_RadiusGive("SlaughterToken", 160, RGF_GIVESELF | RGF_MONSTERS |RGF_CUBE | RGF_NOSIGHT, 1)
+		BOS2 B 2
+		TNT1 A 0 A_JumpIfInventory("SlaughterToken",9,"ReplaceVanilla")
 		TNT1 A 0 A_JumpIfInventory("Curbstomp_Marine", 1, "CurbstompMarine")
 
 	Idle:
@@ -361,6 +365,7 @@ ACTOR HellKnight2 : HellKnight Replaces HellKnight
 		Stop
 
 	XDeath:
+		TNT1 A 0
 	    TNT1 A 0 A_XScream
 		TNT1 A 0 A_NoBlocking
 	    TNT1 A 0 A_CustomMissile ("KnightXDeath", 0, 0, random (0, 360), 2, random (0, 160))
@@ -528,9 +533,7 @@ Death.Explosive:
 		Goto See2
 
     Death.Fatality:
-
 	    TNT1 A 0 A_Pain
-
 		TNT1 A 0 A_JumpIfIntargetInventory("FistsSelected", 1, 1)
 		Goto Death.ExplosiveImpact
 		TNT1 A 0 A_FaceTarget

--- a/LABGUY.txt
+++ b/LABGUY.txt
@@ -28,9 +28,8 @@ ACTOR Labguy: RifleZombie
 	{
 		Spawn:
 		TNT1 A 0
+		SCZA B 2
 		TNT1 A 0 A_GiveInventory("SKLabGuy", 1)
-		TNT1 A 0 A_GiveInventory("TypeZombieMan", 1)
-		SCZA B 1
 		Goto Stand
 
 		Idle:
@@ -922,7 +921,7 @@ ACTOR BrutalizedFormerScientist2: BrutalizedFormerScientist1
 			TNT1 A 0 A_SpawnItemEx("HealthCrueltyBonus2", 0, 0, 25, frandom (-2.5, 2.5), frandom (-2.5, 2.5), 5)
 			TNT1 A 0 A_SpawnItem("BrutalizedFormerScientist3")
 			Stop
-			
+
 		Death.SSG:
 		XDeath:
 			TNT1 A 0 A_SpawnItemEx("HealthCrueltyBonus2", 0, 0, 25, frandom (-2.5, 2.5), frandom (-2.5, 2.5), 5)
@@ -981,7 +980,7 @@ ACTOR BrutalizedFormerScientist3: BrutalizedFormerScientist1
 			FSD1 EFGH 6
 			TNT1 A 0 A_SpawnItem("DeadLabguyFSD1H")
 			Stop
-		
+
 		Death.SSG:
 		XDeath:
 			TNT1 A 0 A_SpawnItemEx("HealthCrueltyBonus2", 0, 0, 25, frandom (-2.5, 2.5), frandom (-2.5, 2.5), 5)

--- a/LostSoul.txt
+++ b/LostSoul.txt
@@ -89,6 +89,22 @@ ACTOR TheLostSoul : LostSoul Replaces LostSoul
         Goto Missile
 
 	Spawn:
+		LSOL A 0
+		TNT1 A 0 ACS_NamedExecuteAlways("BDCHeckClassicMonsters", 0, 0, 0, 0)//Check if Vanilla Mode is activated
+		LSOL A 2
+		TNT1 A 0 A_RadiusGive("SlaughterToken", 192, RGF_GIVESELF | RGF_MONSTERS |RGF_CUBE | RGF_NOSIGHT, 1)
+		LSOL A 2
+		TNT1 A 0 A_JumpIfInventory("SlaughterToken",9,"ReplaceVanilla")
+		Goto Stand
+
+	ReplaceVanilla:
+		TNT1 A 0 A_ChangeFlag("THRUACTORS", 1)
+		TNT1 A 0 A_ChangeFlag("COUNTKILL", 0)
+		TNT1 A 0 A_SpawnItemEx("VanillaLostSoul",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION | SXF_TRANSFERAMBUSHFLAG ,0)
+		Stop
+
+	Idle:
+	Stand:
 		LSOL A 10 BRIGHT A_Look
 		Loop
 

--- a/Mancubus.txt
+++ b/Mancubus.txt
@@ -35,10 +35,12 @@ ACTOR Mancubus : Fatso Replaces Fatso
 	Tag "Mancubus"
 
 	States
-      {
-
+    {
 	ReplaceVanilla:
-		TNT1 A 0 A_GiveInventory ("RifleAmmo", 1)
+		TNT1 A 0 A_ChangeFlag("THRUACTORS", 1)
+		TNT1 A 0 A_ChangeFlag("COUNTKILL", 0)
+		TNT1 A 0 A_SpawnItemEx ("VanillaFatso",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION | SXF_TRANSFERAMBUSHFLAG ,0)
+		Stop
 
 	See:
 		FATT A 0
@@ -125,12 +127,15 @@ ACTOR Mancubus : Fatso Replaces Fatso
 		Goto Stand
 
     Spawn:
-		FATT B 1
+		FATT B 0
 		TNT1 A 0 A_GiveInventory("TargetIsAMancubus")
 		TNT1 A 0 ACS_NamedExecuteAlways("BDCheckStuff")//Check if new monsters are disabled
 		TNT1 A 0 ACS_NamedExecuteAlways("BDCHeckClassicMonsters", 0, 0, 0, 0)//Check if Vanilla Mode is activated
 		FATT B 2
+		TNT1 A 0 A_RadiusGive("SlaughterToken", 128, RGF_GIVESELF | RGF_MONSTERS |RGF_CUBE | RGF_NOSIGHT, 1)
+		FATT B 2
 		TNT1 A 0 A_JumpIfInventory("nonewenemies", 1, "Stand")
+		TNT1 A 0 A_JumpIfInventory("SlaughterToken",9,"ReplaceVanilla")
 		TNT1 A 0 A_Jump(4, "ReplaceVolcabus")
 		Goto Stand
 
@@ -241,7 +246,6 @@ ACTOR Mancubus : Fatso Replaces Fatso
 
 	Melee:
 		TNT1 A 0 A_SpawnItem("HeadshotTarget10", 0, 54)
-		TNT1 A 0 A_JumpIfInventory("RifleAmmo", 1, "Fireballz")
 		TNT1 A 0 A_JumpIfInventory("Enraged", 1, 1)
 		FATT G 10 A_FatRaise
 		TNT1 A 0 A_SpawnItem("HeadshotTarget10", 0, 54)
@@ -475,6 +479,7 @@ ACTOR Mancubus : Fatso Replaces Fatso
 	Death.ExplosiveImpact:
 	Death.Landmine:
 	Death.ExtremePunches:
+		TNT1 A 0
         TNT1 A 0 A_CustomMissile ("MeatDeath", 0, 0, random (0, 360), 2, random (0, 160))
 		TNT1 AAAAAAAAAAAAA 0 A_CustomMissile ("BloodMistExtraBig", 30, 0, random (0, 360), 2, random (60, 90))
 		TNT1 AAAAAA 0 A_CustomMissile ("SuperGoreSpawner", 30, 0, random (0, 360), 2, random (40, 70))
@@ -537,7 +542,7 @@ Pain.Taunt:
     FATT R 5
     FATT QPONMLK 5
     Goto See
-       }
+	}
 }
 
 ACTOR BigFireBall Replaces Fatshot

--- a/PainElemental.txt
+++ b/PainElemental.txt
@@ -41,6 +41,22 @@ ACTOR PainElemental1 Replaces PainElemental
 	States
 	{
 	Spawn:
+		PAIN A 0
+		TNT1 A 0 ACS_NamedExecuteAlways("BDCHeckClassicMonsters", 0, 0, 0, 0)//Check if Vanilla Mode is activated
+		PAIN A 2
+		TNT1 A 0 A_RadiusGive("SlaughterToken", 192, RGF_GIVESELF | RGF_MONSTERS |RGF_CUBE | RGF_NOSIGHT, 1)
+		PAIN A 2
+		TNT1 A 0 A_JumpIfInventory("SlaughterToken",9,"ReplaceVanilla")
+		Goto Stand
+
+	ReplaceVanilla:
+		TNT1 A 0 A_ChangeFlag("THRUACTORS", 1)
+		TNT1 A 0 A_ChangeFlag("COUNTKILL", 0)
+		TNT1 A 0 A_SpawnItemEx("VanillaPainElemental",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION | SXF_TRANSFERAMBUSHFLAG ,0)
+		Stop
+
+	Idle:
+	Stand:
 		PAIN A 10 A_Look
 		Loop
 

--- a/Revenant.txt
+++ b/Revenant.txt
@@ -36,7 +36,7 @@ ACTOR Revenant1: Revenant Replaces Revenant
 	MaxDropOffHeight 32
 	DeathHeight 0
 	BurnHeight 0
-	Radius 18
+	Radius 20
 	Height 58
 	Scale 0.9
 	Species "Revenant"
@@ -51,9 +51,13 @@ ACTOR Revenant1: Revenant Replaces Revenant
 
     Spawn:
 		SKEL B 0
-		TNT1 A 0 ACS_NamedExecuteAlways("BDCHeckClassicMonsters", 0, 0, 0, 0)//Check if Vanilla Mode is activated
-	    TNT1 A 0 A_JumpIfInventory("Curbstomp_Marine", 1, "FatalityMarine")
 		TNT1 A 0 A_GiveInventory("IsARevenant", 1)
+		TNT1 A 0 ACS_NamedExecuteAlways("BDCHeckClassicMonsters", 0, 0, 0, 0)//Check if Vanilla Mode is activated
+		SKEL B 2
+		TNT1 A 0 A_RadiusGive("SlaughterToken", 128, RGF_GIVESELF | RGF_MONSTERS |RGF_CUBE | RGF_NOSIGHT, 1)
+		SKEL B 2
+		TNT1 A 0 A_JumpIfInventory("SlaughterToken",9,"ReplaceVanilla")
+	    TNT1 A 0 A_JumpIfInventory("Curbstomp_Marine", 1, "FatalityMarine")
 
 	Idle:
 	Spawn2:
@@ -458,6 +462,7 @@ ACTOR Revenant1: Revenant Replaces Revenant
 	Death.ExplosiveImpact:
 	Death.Explosive:
 	XDeath:
+		TNT1 A 0
 		TNT1 AAAAA 0 A_CustomMissile ("RevenantDust", 60, 0, random (0, 360), 2, random (0, 360))
 		TNT1 AAAAAA 0 A_CustomMissile ("RevenantDust2", 60, 0, random (0, 360), 2, random (0, 360))
         TNT1 A 0 A_CustomMissile ("XDeathRevenantHead", 52, 0, random (0, 360), 2, random (0, 160))

--- a/Sergeants.txt
+++ b/Sergeants.txt
@@ -3,7 +3,7 @@ ACTOR ShotgunGuy1: ShotgunGuy Replaces ShotgunGuy
 	Game Doom
 	Health 40
 	SpawnID 1
-	Radius 16
+	Radius 20
 	Height 39
 	Mass 300
 	Speed 5
@@ -74,12 +74,14 @@ ACTOR ShotgunGuy1: ShotgunGuy Replaces ShotgunGuy
 		TNT1 A 0 A_SpawnItemEx ("VanillaShotgunguy",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION | SXF_TRANSFERAMBUSHFLAG ,0)
 		Stop
     Spawn:
-		SHID A 1
+		SHID A 0
 		TNT1 A 0 A_GiveInventory("SKShotgunGuy", 1)
-		TNT1 A 0 A_GiveInventory("TypeSergeant", 1)
 		TNT1 A 0 ACS_NamedExecuteAlways("BDCheckStuff")//Check if new monsters are disabled
 		TNT1 A 0 ACS_NamedExecuteAlways("BDCHeckClassicMonsters", 0, 0, 0, 0)//Check if Vanilla Mode is activated
 		SHID A 2
+		TNT1 A 0 A_RadiusGive("SlaughterToken", 128, RGF_GIVESELF | RGF_MONSTERS |RGF_CUBE | RGF_NOSIGHT, 1)
+		SHID A 2
+		TNT1 A 0 A_JumpIfInventory("SlaughterToken",9,"ReplaceVanilla")
 		TNT1 A 0 A_JumpIfInventory("nonewenemies", 1, "Stand")
 		TNT1 A 0 A_Jump(64, "ReplaceSMG")
 		Goto Stand
@@ -331,15 +333,16 @@ ACTOR ShotgunGuy1: ShotgunGuy Replaces ShotgunGuy
 	Pain.ExplosiveImpact:
 	Pain.ExtremePunches:
 	Pain.Explosive:
-	TNT1 A 0 A_ChangeFLag("NODROPOFF", 0)
-	TNT1 A 0 A_ChangeFlag("NOBLOCKMONST", 1)
-	         TNT1 A 0
-	         TNT1 A 0 A_Pain
-		 TNT1 A 0 A_JumpIfInventory ("IsDown", 1, "Pain")
-		 		    TNT1 A 0 A_TakeInventory("SKShotgunGuy", 1)
-         TNT1 A 0 A_GiveInventory("IsDown", 1)
-        TNT1 A 0 ThrustThingZ(0,40,0,1)
-         SPO4 UUVWXY 4
+		TNT1 A 0
+		TNT1 A 0 A_ChangeFLag("NODROPOFF", 0)
+		TNT1 A 0 A_ChangeFlag("NOBLOCKMONST", 1)
+		TNT1 A 0
+		TNT1 A 0 A_Pain
+		TNT1 A 0 A_JumpIfInventory ("IsDown", 1, "Pain")
+		TNT1 A 0 A_TakeInventory("SKShotgunGuy", 1)
+		TNT1 A 0 A_GiveInventory("IsDown", 1)
+		TNT1 A 0 ThrustThingZ(0,40,0,1)
+		SPO4 UUVWXY 4
 		Goto FallingAfterImpact
 
 	Pain.LowKick:
@@ -1072,6 +1075,7 @@ ACTOR ShotgunGuy1: ShotgunGuy Replaces ShotgunGuy
       Stop
 
 	XDeath:
+		TNT1 A 0
 		TNT1 A 0 A_NoBlocking
 		TNT1 A 0 A_GiveToTarget("SoulAmmo", 10)
 		TNT1 A 0 A_XScream
@@ -1084,6 +1088,7 @@ ACTOR ShotgunGuy1: ShotgunGuy Replaces ShotgunGuy
         Stop
 
 	Death.Desintegrate:
+		TNT1 A 0
         TNT1 A 0 A_XScream
         TNT1 A 0 A_NoBlocking
 		TNT1 A 0 A_GiveToTarget("SoulAmmo", 10)
@@ -1277,12 +1282,11 @@ ACTOR ShotgunGuy1: ShotgunGuy Replaces ShotgunGuy
 
 ACTOR SMGGuy: ShotgunGuy1
 {
-DropItem "SMGSpawner"
-Tag "SMG Zombie"
-Obituary "%o got punctured by a SMG Zombie."
+	DropItem "SMGSpawner"
+	Tag "SMG Zombie"
+	Obituary "%o got punctured by a SMG Zombie."
 	States
 	{
-
 	Pain.Avoid:
 	  TNT1 A 0
 	  TNT1 A 0 A_Jump(255, "AvoidLeft", "AvoidRight")
@@ -1309,7 +1313,6 @@ Obituary "%o got punctured by a SMG Zombie."
 		TNT1 A 0 ACS_NamedExecuteAlways("BDCHeckClassicMonsters", 0, 0, 0, 0)//Check if Vanilla Mode is activated
 		  TNT1 A 0
 		  TNT1 A 0 A_GiveInventory("SKShotgunGuy", 1)
-		  TNT1 A 0 A_GiveInventory("TypeSergeant", 1)
 		  TNT1 A 0 A_TakeInventory("SergeantAmmo", 6)
 		  TNT1 A 0 A_GiveInventory("SergeantAmmo", random(0,5))
 		  PSS3 B 1

--- a/Spectre.txt
+++ b/Spectre.txt
@@ -10,10 +10,13 @@ ACTOR Spectro: BullDemon Replaces Spectre
 	States
 	{
     Spawn:
-		SPEC A 1 BRIGHT
+		SPEC A 0 BRIGHT
 		TNT1 A 0 ACS_NamedExecuteAlways("BDCHeckClassicMonsters", 0, 0, 0, 0)//Check if Vanilla Mode is activated
 		TNT1 A 0 ACS_NamedExecuteAlways("BDCheckFuzzySpectre", 0, 0, 0, 0)//Check if FuzzySpectres is enabled
 		SPEC A 2 BRIGHT
+		TNT1 A 0 A_RadiusGive("SlaughterToken", 192, RGF_GIVESELF | RGF_MONSTERS |RGF_CUBE | RGF_NOSIGHT, 1)
+		SPEC A 2 BRIGHT
+		TNT1 A 0 A_JumpIfInventory("SlaughterToken",9,"ReplaceVanilla")
 	Idle:
 	Spawned:
 		TNT1 A 0

--- a/Spiders.txt
+++ b/Spiders.txt
@@ -48,9 +48,19 @@ ACTOR Arachnotron1: Arachnotron replaces Arachnotron
 	Spawn:
 		BSPI A 0
 		TNT1 A 0 ACS_NamedExecuteAlways("BDCheckStuff")//Check if new monsters are disabled
+		BSPI A 2
+		TNT1 A 0 A_RadiusGive("SlaughterToken", 384, RGF_GIVESELF | RGF_MONSTERS |RGF_CUBE | RGF_NOSIGHT, 1)
+		BSPI A 2
 		TNT1 A 0 A_JumpIfInventory("nonewenemies", 1, "Stand")
+		TNT1 A 0 A_JumpIfInventory("SlaughterToken",9,"ReplaceVanilla")
 		TNT1 A 0 A_Jump(4, "ReplaceSpiders2")
 		Goto Stand
+
+	ReplaceVanilla:
+		TNT1 A 0 A_ChangeFlag("THRUACTORS", 1)
+		TNT1 A 0 A_ChangeFlag("COUNTKILL", 0)
+		TNT1 A 0 A_SpawnItemEx ("VanillaArachnotron",0,0,0,0,0,0,0,SXF_NOCHECKPOSITION | SXF_TRANSFERAMBUSHFLAG ,0)
+		Stop
 
 	ReplaceSpiders2:
 		TNT1 A 0 A_JumpIf((CeilingZ - FloorZ) < 73,"Stand")

--- a/Tokens.txt
+++ b/Tokens.txt
@@ -1101,11 +1101,6 @@ Actor ZombiemanAmmo : Inventory
 inventory.maxamount 20
 }
 
-Actor TypeZombieman : Inventory
-{
-inventory.maxamount 1
-}
-
 Actor EverSeenThePlayer : Inventory
 {
 inventory.maxamount 1
@@ -1119,11 +1114,6 @@ inventory.maxamount 1
 Actor SergeantAmmo : Inventory
 {
 inventory.maxamount 6
-}
-
-Actor TypeSergeant : Inventory
-{
-inventory.maxamount 1
 }
 
 Actor EatMe : Inventory
@@ -1526,4 +1516,9 @@ inventory.maxamount 1
 Actor ComeEatMeDemon : Inventory
 {
 inventory.maxamount 1
+}
+
+ACTOR SlaughterToken : Inventory
+{
+	Inventory.MaxAmount 9
 }

--- a/VanillaMonsters.txt
+++ b/VanillaMonsters.txt
@@ -536,6 +536,7 @@ ACTOR VanillaRevenant
 	MeleeThreshold 196
 	+MISSILEMORE
 	+FLOORCLIP
+	+NOBLOOD
 	SeeSound "skeleton/sight"
 	PainSound "skeleton/pain"
 	DeathSound "skeleton/death"
@@ -808,6 +809,160 @@ ACTOR VanillaCyberdemon
 		CYBR NO 10
 		CYBR P 30
 		CYBR P -1 A_BossDeath
+		Stop
+	}
+}
+
+ACTOR VanillaArachnotron
+{
+	Game Doom
+	SpawnID 6
+	Health 500
+	Radius 64
+	Height 64
+	Mass 600
+	Speed 12
+	PainChance 128
+	Monster
+	+FLOORCLIP
+	+BOSSDEATH
+	SeeSound "baby/sight"
+	PainSound "baby/pain"
+	DeathSound "baby/death"
+	ActiveSound "baby/active"
+	Obituary "$OB_BABY"
+	Tag "Arachnotron"
+	Damagefactor "TeleportRemover", 0.0
+	States
+	{
+	Spawn:
+		BSPI AB 10 A_Look
+		Loop
+	See:
+		BSPI A 20
+		BSPI A 3 A_BabyMetal
+		BSPI ABBCC 3 A_Chase
+		BSPI D 3 A_BabyMetal
+		BSPI DEEFF 3 A_Chase
+		Goto See+1
+	Missile:
+		BSPI A 20 BRIGHT A_FaceTarget
+		BSPI G 4 BRIGHT A_BspiAttack
+		BSPI H 4 BRIGHT
+		BSPI H 1 BRIGHT A_SpidRefire
+		Goto Missile+1
+	Pain:
+		BSPI I 3
+		BSPI I 3 A_Pain
+		Goto See+1
+	Death:
+		BSPI J 20 A_Scream
+		BSPI K 7 A_NoBlocking
+		BSPI LMNO 7
+		BSPI P -1 A_BossDeath
+		Stop
+    Raise:
+		BSPI P 5
+		BSPI ONMLKJ 5
+		Goto See+1
+	}
+}
+
+ACTOR VanillaPainElemental
+{
+	Game Doom
+	SpawnID 115
+	Health 400
+	Radius 31
+	Height 56
+	Mass 400
+	Speed 8
+	PainChance 128
+	Monster
+	+FLOAT
+	+NOGRAVITY
+	SeeSound "pain/sight"
+	PainSound "pain/pain"
+	DeathSound "pain/death"
+	ActiveSound "pain/active"
+	Tag "PainElemental"
+	Damagefactor "TeleportRemover", 0.0
+	States
+	{
+	Spawn:
+		PAIN A 10 A_Look
+		Loop
+	See:
+		PAIN AABBCC 3 A_Chase
+		Loop
+	Missile:
+		PAIN D 5 A_FaceTarget
+		PAIN E 5 A_FaceTarget
+		PAIN F 4 BRIGHT A_FaceTarget
+		PAIN F 1 BRIGHT A_PainAttack("VanillaLostSoul")
+		Goto See
+	Pain:
+		PAIN G 6
+		PAIN G 6 A_Pain
+		Goto See
+	Death:
+		PAIN H 8 BRIGHT
+		PAIN I 8 BRIGHT A_Scream
+		PAIN JK 8 BRIGHT
+		PAIN L 8 BRIGHT A_PainDie
+		PAIN M 8 BRIGHT
+		Stop
+	Raise:
+		PAIN MLKJIH 8
+		Goto See
+	}
+}
+
+ACTOR VanillaLostSoul
+{
+	Game Doom
+	SpawnID 110
+	Health 100
+	Radius 16
+	Height 56
+	Mass 50
+	Speed 8
+	Damage 3
+	PainChance 256
+	Monster
+	+FLOAT +NOGRAVITY +MISSILEMORE +DONTFALL +NOICEDEATH +NOBLOOD
+	AttackSound "skull/melee"
+	PainSound "skull/pain"
+	DeathSound "skull/death"
+	ActiveSound "skull/active"
+	RenderStyle SoulTrans
+	Obituary "$OB_SKULL"
+	Tag "Lost Soul"
+	Damagefactor "TeleportRemover", 0.0
+	States
+	{
+	Spawn:
+		SKUL AB 10 BRIGHT A_Look
+		Loop
+	See:
+		SKUL AB 6 BRIGHT A_Chase
+		Loop
+	Missile:
+		SKUL C 10 BRIGHT A_FaceTarget
+		SKUL D 4 BRIGHT A_SkullAttack
+		SKUL CD 4 BRIGHT
+		Goto Missile+2
+	Pain:
+		SKUL E 3 BRIGHT
+		SKUL E 3 BRIGHT A_Pain
+		Goto See
+	Death:
+		SKUL F 6 BRIGHT
+		SKUL G 6 BRIGHT A_Scream
+		SKUL H 6 BRIGHT
+		SKUL I 6 BRIGHT A_NoBlocking
+		SKUL J 6
+		SKUL K 6
 		Stop
 	}
 }

--- a/Zombiemen.txt
+++ b/Zombiemen.txt
@@ -2,7 +2,7 @@ ACTOR RifleZombie Replaces ZombieMan
 {
 	Game Doom
 	Health 40
-	Radius 18
+	Radius 20
 	Height 44
     Speed 5
 	Mass 300
@@ -49,15 +49,17 @@ ACTOR RifleZombie Replaces ZombieMan
 	{
 
 	 Spawn:
-		PSSS B 1
-		TNT1 A 0 A_GiveInventory("SKZombieman", 1)
-		TNT1 A 0 A_GiveInventory("TypeZombieMan", 1)
+		PSSS B 0
 		TNT1 A 0 ACS_NamedExecuteAlways("BDCheckStuff")//Check if new monsters are disabled
 		TNT1 A 0 ACS_NamedExecuteAlways("BDCHeckClassicMonsters", 0, 0, 0, 0)//Check if Vanilla Mode is activated
 		PSSS B 2
+		TNT1 A 0 A_RadiusGive("SlaughterToken", 128, RGF_GIVESELF | RGF_MONSTERS |RGF_CUBE | RGF_NOSIGHT, 1)
+		PSSS B 2
+		TNT1 A 0 A_GiveInventory("SKZombieman", 1)
 		TNT1 A 0 A_JumpIfInventory("nonewenemies", 1, "Stand")
-		TNT1 A 0 A_Jump(4, "ReplaceAxeman")
+		TNT1 A 0 A_JumpIfInventory("SlaughterToken",9,"ReplaceVanilla")
 		TNT1 A 0 A_Jump(168, "ReplacePistol")
+		TNT1 A 0 A_Jump(4, "ReplaceAxeman")
 	Goto Stand
 
 	ReplacePistol:
@@ -1059,6 +1061,7 @@ ACTOR RifleZombie Replaces ZombieMan
         Stop
 
 	Death.Desintegrate:
+		TNT1 A 0
         TNT1 A 0 A_XScream
         TNT1 A 0 A_NoBlocking
         TNT1 A 0 A_SpawnItem("DesintegratedHuman")
@@ -1254,6 +1257,7 @@ ACTOR RifleZombie Replaces ZombieMan
         Stop
 
 	XDeath:
+		TNT1 A 0
   	    TNT1 A 0 A_XScream
 		TNT1 A 0 A_NoBlocking
 		TNT1 A 0 A_FaceTarget
@@ -1309,6 +1313,7 @@ ACTOR RifleZombie Replaces ZombieMan
 
 	Death.ExplosiveImpact:
 	Death.Explosive:
+		TNT1 A 0
 		TNT1 A 0 A_ChangeFLag("NODROPOFF", 0)
 		TNT1 A 0
 		TNT1 A 0 A_GiveToTarget("SoulAmmo", 10)
@@ -1455,7 +1460,6 @@ Tag "Pistol Zombie"
 	{
 	Spawn:
 		PSSS B 0
-		TNT1 A 0 A_GiveInventory("TypeZombieMan", 1)
 		TNT1 A 0 A_TakeInventory("ZombiemanAmmo", 20)
 		TNT1 A 0 A_GiveInventory("SKZombieMan", 1)
 		TNT1 A 0 A_GiveInventory("ZombieManAmmo", random(1,10))
@@ -1593,8 +1597,6 @@ Tag "Pistol Zombie"
         TNT1 A 0 A_JumpIfInventory("ZombieManAmmo", 15, "Reload")
         Goto SeeContinue
 
-
-
   Reload:
 		TNT1 A 0 A_TakeInventory("ZombieManAmmo", 20)
 		TNT1 A 0 A_SpawnItem ("HeadshotTarget20", 0, 36,0)
@@ -1635,13 +1637,11 @@ Tag "Pistol Zombie"
         TNT1 A 0 A_SpawnItem("PistolZombie")
         Stop
 
-
 	Pain.Cut:
 	Pain.Saw:
 		TNT1 A 0
 		TNT1 A 0 A_Stop
 	Pain:
-
         TNT1 A 0 A_JumpIfInventory ("IsDown", 1, 8)
 		TNT1 A 0 A_SpawnItem ("HeadshotTarget4", 0, 36,0)
 		PSPO G 2


### PR DESCRIPTION
On spawn all monsters radiusgive a "SlaughterToken" to themselves and any other monsters within a distance of six times their radius.
If 9 or more of said tokens are in a monster's inventory then it will jump to the ReplaceVanilla state and replace the monster(s) with the vanilla variants for slaughter WADs.
Also created the remaining vanilla variants for monsters who did not have them (arachnotron, painelemental, loustsoul, and enabled the fatso).  And implemented GLDEFS for the vanilla lostsoul.
Optimized the Baron's see states.