### PR TITLE
Meat shield stuff

### DIFF
--- a/CguyShield.txt
+++ b/CguyShield.txt
@@ -152,7 +152,20 @@ ACTOR ThrowedChaingunguy: ThrowedZman
 	Death.Explosive:
 	Death.Chaingun:
 		TNT1 A 0
-		TNT1 A 0 A_SpawnItem("ChainXDeath")
+		TNT1 AAAAAA 0 bright A_CustomMissile ("SuperGoreSpawner", 5, 0, random (0, 360), 2, random (30, 180))
+		TNT1 AAAAAAAAA 0 A_CustomMissile ("CeilBloodLauncherLong", 0, 0, random (0, 360), 2, random (50, 130))
+		TNT1 A 0 A_CustomMissile ("XDeathChaingunguyHeadOnXDeath", 42, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AA 0 A_CustomMissile ("XDeathChainArm", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AA 0 A_CustomMissile ("XDeathChainLeg", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AA 0 A_CustomMissile ("XDeath1", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AA 0 A_CustomMissile ("XDeath2", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AAAA 0 A_CustomMissile ("XDeath2b", 15, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AAAA 0 A_CustomMissile ("XDeath3b", 15, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AA 0 A_CustomMissile ("XDeathSkinPiece2", 15, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AA 0 A_CustomMissile ("XDeathSkinPiece1", 15, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AAA 0 A_CustomMissile ("SuperGoreSpawner", 30, 0, random (0, 360), 2, random (30, 60))
+		TNT1 A 0 A_SpawnItem("BigBloodSpot")
+		TNT1 AAAAAAAA 0 A_CustomMissile ("BloodMistExtraBig", 30, 0, random (0, 360), 2, random (40, 90))
 		Stop
 	}
 }
@@ -244,6 +257,7 @@ ACTOR ThrowedChaingunguyNoHead: ThrowedChaingunguy
 		TNT1 AAAAAA 0 bright A_CustomMissile ("SuperGoreSpawner", 5, 0, random (0, 360), 2, random (30, 180))
 		TNT1 AAAAAAAAA 0 A_CustomMissile ("CeilBloodLauncherLong", 0, 0, random (0, 360), 2, random (50, 130))
 		TNT1 AA 0 A_CustomMissile ("XDeathChainArm", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AA 0 A_CustomMissile ("XDeathChainLeg", 32, 0, random (0, 360), 2, random (10, 90))
 		TNT1 AA 0 A_CustomMissile ("XDeath1", 32, 0, random (0, 360), 2, random (10, 90))
 		TNT1 AA 0 A_CustomMissile ("XDeath2", 32, 0, random (0, 360), 2, random (10, 90))
 		TNT1 AAAA 0 A_CustomMissile ("XDeath2b", 15, 0, random (0, 360), 2, random (10, 90))

--- a/CguyShield.txt
+++ b/CguyShield.txt
@@ -147,6 +147,7 @@ ACTOR ThrowedChaingunguy: ThrowedZman
 		NULL A 0 A_CustomMissile ("ThrowedChaingunguyRicochet", 0, 0, 180, 2, 32)
 		Stop
 
+	Death.Shotgun:
 	Death.Gibs:
 	Death.Explosive:
 	Death.Chaingun:
@@ -235,11 +236,23 @@ ACTOR ThrowedChaingunguyNoHead: ThrowedChaingunguy
 		NULL A 0 A_CustomMissile ("ThrowedChaingunguyNoHeadRicochet", 0, 0, 180, 2, 32)
 		Stop
 
+	Death.Shotgun:
 	Death.Gibs:
 	Death.Explosive:
 	Death.Chaingun:
 		TNT1 A 0
-		TNT1 A 0 A_SpawnItem("ChainXDeath")
+		TNT1 AAAAAA 0 bright A_CustomMissile ("SuperGoreSpawner", 5, 0, random (0, 360), 2, random (30, 180))
+		TNT1 AAAAAAAAA 0 A_CustomMissile ("CeilBloodLauncherLong", 0, 0, random (0, 360), 2, random (50, 130))
+		TNT1 AA 0 A_CustomMissile ("XDeathChainArm", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AA 0 A_CustomMissile ("XDeath1", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AA 0 A_CustomMissile ("XDeath2", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AAAA 0 A_CustomMissile ("XDeath2b", 15, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AAAA 0 A_CustomMissile ("XDeath3b", 15, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AA 0 A_CustomMissile ("XDeathSkinPiece2", 15, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AA 0 A_CustomMissile ("XDeathSkinPiece1", 15, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AAA 0 A_CustomMissile ("SuperGoreSpawner", 30, 0, random (0, 360), 2, random (30, 60))
+		TNT1 A 0 A_SpawnItem("BigBloodSpot")
+		TNT1 AAAAAAAA 0 A_CustomMissile ("BloodMistExtraBig", 30, 0, random (0, 360), 2, random (40, 90))
 		Stop
 	}
 }

--- a/EvilMarineShield.txt
+++ b/EvilMarineShield.txt
@@ -148,6 +148,7 @@ Translation "112:127=[64,64,64]:[0,0,0]"
 		NULL A 0 A_CustomMissile ("ThrowedEvilMarineRicochet", 0, 0, 180, 2, 32)
 		Stop
 
+	Death.Shotgun:
 	Death.Gibs:
 	Death.Explosive:
 	Death.Chaingun:

--- a/ImpShield.txt
+++ b/ImpShield.txt
@@ -151,7 +151,24 @@ ACTOR ThrowedImp: ThrowedZman
 	Death.Explosive:
 	Death.Shotgun:
 		TNT1 A 0
-		TNT1 A 0 A_SpawnItem("ImpXDeath")
+		TNT1 AAA 0 A_CustomMissile ("SuperWallRedBlood", 40, 0, random (0, 360), 2, random (-15, 15))
+		TNT1 AAAAAAAAA 0 A_CustomMissile ("CeilBloodLauncherLong", 0, 0, random (0, 360), 2, random (50, 130))
+		TNT1 A 0 A_CustomMissile ("XDeathImpHeadOnXDeath", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_CustomMissile ("XDeathImpArm", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AAA 0 A_CustomMissile ("SuperGoreSpawner", 30, 0, random (0, 360), 2, random (30, 60))
+		TNT1 A 0 A_CustomMissile ("XDeathHalfImpUpperPart32", 32, 0, random (0, 360), 2, random (10, 60))
+		TNT1 AA 0 A_CustomMissile ("XDeath1", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_CustomMissile ("XDeathOrgan1", 24, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_CustomMissile ("XDeathOrgan2", 24, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AAAA 0 A_CustomMissile ("XDeath2b", 15, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AAAA 0 A_CustomMissile ("XDeath3b", 15, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AA 0 A_CustomMissile ("XDeathSkinPiece2", 15, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AA 0 A_CustomMissile ("XDeathSkinPiece1", 15, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AAAAAAA 0 A_CustomMissile ("Guts", 32, 0, random (0, 360), 2, random (60, 90))
+		TNT1 AA 0 A_CustomMissile ("XDeathImpLeg", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_SpawnItem ("BigBloodSpot")
+		TNT1 A 1
+		TNT1 AAAAAA 0 A_CustomMissile ("BloodMistExtraBig", 30, 0, random (0, 360), 2, random (40, 90))
 		Stop
 	}
 }

--- a/ImpShield.txt
+++ b/ImpShield.txt
@@ -256,7 +256,23 @@ ACTOR ThrowedImpNoHead: ThrowedImp
 	Death.Explosive:
 	Death.Shotgun:
 		TNT1 A 0
-		TNT1 A 0 A_SpawnItem("ImpXDeath")
+		TNT1 AAA 0 A_CustomMissile ("SuperWallRedBlood", 40, 0, random (0, 360), 2, random (-15, 15))
+		TNT1 AAAAAAAAA 0 A_CustomMissile ("CeilBloodLauncherLong", 0, 0, random (0, 360), 2, random (50, 130))
+		TNT1 A 0 A_CustomMissile ("XDeathImpArm", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AAA 0 A_CustomMissile ("SuperGoreSpawner", 30, 0, random (0, 360), 2, random (30, 60))
+		TNT1 A 0 A_CustomMissile ("XDeathHalfImpUpperPart32", 32, 0, random (0, 360), 2, random (10, 60))
+		TNT1 AA 0 A_CustomMissile ("XDeath1", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_CustomMissile ("XDeathOrgan1", 24, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_CustomMissile ("XDeathOrgan2", 24, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AAAA 0 A_CustomMissile ("XDeath2b", 15, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AAAA 0 A_CustomMissile ("XDeath3b", 15, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AA 0 A_CustomMissile ("XDeathSkinPiece2", 15, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AA 0 A_CustomMissile ("XDeathSkinPiece1", 15, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AAAAAAA 0 A_CustomMissile ("Guts", 32, 0, random (0, 360), 2, random (60, 90))
+		TNT1 AA 0 A_CustomMissile ("XDeathImpLeg", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_SpawnItem ("BigBloodSpot")
+		TNT1 A 1
+		TNT1 AAAAAA 0 A_CustomMissile ("BloodMistExtraBig", 30, 0, random (0, 360), 2, random (40, 90))
 		Stop
 	}
 }

--- a/Melee.txt
+++ b/Melee.txt
@@ -767,7 +767,7 @@ ACTOR Melee_Attacks : BrutalWeapon Replaces Fist
         TNT1 A 0 A_PlaySound("skeleton/swing")
 		TNT1 A 0 A_TakeInventory("HasImpFatality",10)
 		TNT1 A 0 A_Giveinventory("Punching",1)
-        PTG2 H 1 A_FireCustomMissile("ThrowedImpDead", 0, 0, 0, 0)
+        PTG2 H 1 A_FireCustomMissile("ThrowedImpNoHead", 0, 0, 0, 0)
         PTG2 IJLMN 1
 		Goto Ready
 

--- a/NaziShield.txt
+++ b/NaziShield.txt
@@ -152,7 +152,25 @@ ACTOR ThrowedNazi: ThrowedZman
 	Death.Explosive:
 	Death.Chaingun:
 		TNT1 A 0
-		TNT1 A 0 A_SpawnItem("SargeXDeath")
+		TNT1 AAAAA 0 A_CustomMissile ("SuperWallRedBlood", 40, 0, random (0, 360), 2, random (-15, 15))
+		TNT1 AAAAAAAAA 0 A_CustomMissile ("CeilBloodLauncherLong", 0, 0, random (0, 360), 2, random (50, 130))
+		TNT1 A 0 A_SpawnItem("NaziHeadExplode", 0, 50)
+		TNT1 A 0 A_CustomMissile ("XDeathArm1", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AA 0 A_CustomMissile ("XDeath1", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AAA 0 A_CustomMissile ("SuperGoreSpawner", 30, 0, random (0, 360), 2, random (30, 60))
+		TNT1 AAAA 0 A_CustomMissile ("XDeath2b", 15, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AAAA 0 A_CustomMissile ("XDeath3b", 15, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AA 0 A_CustomMissile ("XDeathSkinPiece2", 15, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AA 0 A_CustomMissile ("XDeathSkinPiece1", 15, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_CustomMissile ("XDeathOrgan1", 24, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_CustomMissile ("XDeathOrgan2", 24, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_CustomMissile ("XDeathHalfShotgunguyNoArmNoHead", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AAAAAAA 0 A_CustomMissile ("Guts", 32, 0, random (0, 360), 2, random (60, 90))
+		TNT1 A 0 A_CustomMissile ("XDeathSargeLeg2", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_CustomMissile ("GibSargeBoot", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_SpawnItem ("BigBloodSpot")
+		TNT1 A 1
+		TNT1 AAAAAA 0 A_CustomMissile ("BloodMistExtraBig", 30, 0, random (0, 360), 2, random (40, 90))
 		Stop
 	}
 }

--- a/NaziShield.txt
+++ b/NaziShield.txt
@@ -147,6 +147,7 @@ ACTOR ThrowedNazi: ThrowedZman
 		NULL A 0 A_CustomMissile ("ThrowedNaziRicochet", 0, 0, 180, 2, 32)
 		Stop
 
+	Death.Shotgun:
 	Death.Gibs:
 	Death.Explosive:
 	Death.Chaingun:
@@ -233,11 +234,29 @@ ACTOR ThrowedNaziNoHead: ThrowedNazi
 		NULL A 0 A_CustomMissile ("ThrowedNaziRicochet", 0, 0, 180, 2, 32)
 		Stop
 
+	Death.Shotgun:
 	Death.Gibs:
 	Death.Explosive:
 	Death.Chaingun:
 		TNT1 A 0
-		TNT1 A 0 A_SpawnItem("SargeXDeath")
+		TNT1 AAAAA 0 A_CustomMissile ("SuperWallRedBlood", 40, 0, random (0, 360), 2, random (-15, 15))
+		TNT1 AAAAAAAAA 0 A_CustomMissile ("CeilBloodLauncherLong", 0, 0, random (0, 360), 2, random (50, 130))
+		TNT1 A 0 A_CustomMissile ("XDeathArm1", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AA 0 A_CustomMissile ("XDeath1", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AAA 0 A_CustomMissile ("SuperGoreSpawner", 30, 0, random (0, 360), 2, random (30, 60))
+		TNT1 AAAA 0 A_CustomMissile ("XDeath2b", 15, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AAAA 0 A_CustomMissile ("XDeath3b", 15, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AA 0 A_CustomMissile ("XDeathSkinPiece2", 15, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AA 0 A_CustomMissile ("XDeathSkinPiece1", 15, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_CustomMissile ("XDeathOrgan1", 24, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_CustomMissile ("XDeathOrgan2", 24, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_CustomMissile ("XDeathHalfShotgunguyNoArmNoHead", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AAAAAAA 0 A_CustomMissile ("Guts", 32, 0, random (0, 360), 2, random (60, 90))
+		TNT1 A 0 A_CustomMissile ("XDeathSargeLeg2", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_CustomMissile ("GibSargeBoot", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_SpawnItem ("BigBloodSpot")
+		TNT1 A 1
+		TNT1 AAAAAA 0 A_CustomMissile ("BloodMistExtraBig", 30, 0, random (0, 360), 2, random (40, 90))
 		Stop
 	}
 }

--- a/SguyShield.txt
+++ b/SguyShield.txt
@@ -237,7 +237,24 @@ ACTOR ThrowedShotgunguyNoHead: ThrowedZman
 	Death.Explosive:
 	Death.Shotgun:
 		TNT1 A 0
-		TNT1 A 0 A_SpawnItem("SargeXDeath")
+		TNT1 AAAAA 0 A_CustomMissile ("SuperWallRedBlood", 40, 0, random (0, 360), 2, random (-15, 15))
+		TNT1 AAAAAAAAA 0 A_CustomMissile ("CeilBloodLauncherLong", 0, 0, random (0, 360), 2, random (50, 130))
+		TNT1 A 0 A_CustomMissile ("XDeathArm1", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AA 0 A_CustomMissile ("XDeath1", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AAA 0 A_CustomMissile ("SuperGoreSpawner", 30, 0, random (0, 360), 2, random (30, 60))
+		TNT1 AAAA 0 A_CustomMissile ("XDeath2b", 15, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AAAA 0 A_CustomMissile ("XDeath3b", 15, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AA 0 A_CustomMissile ("XDeathSkinPiece2", 15, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AA 0 A_CustomMissile ("XDeathSkinPiece1", 15, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_CustomMissile ("XDeathOrgan1", 24, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_CustomMissile ("XDeathOrgan2", 24, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_CustomMissile ("XDeathHalfShotgunguyNoArmNoHead", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AAAAAAA 0 A_CustomMissile ("Guts", 32, 0, random (0, 360), 2, random (60, 90))
+		TNT1 A 0 A_CustomMissile ("XDeathSargeLeg2", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_CustomMissile ("GibSargeBoot", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_SpawnItem ("BigBloodSpot")
+		TNT1 A 1
+		TNT1 AAAAAA 0 A_CustomMissile ("BloodMistExtraBig", 30, 0, random (0, 360), 2, random (40, 90))
 		Stop
 	}
 }

--- a/SguyShield.txt
+++ b/SguyShield.txt
@@ -151,7 +151,25 @@ ACTOR ThrowedShotgunguy: ThrowedZman
 	Death.Explosive:
 	Death.Shotgun:
 		TNT1 A 0
-		TNT1 A 0 A_SpawnItem("SargeXDeath")
+		TNT1 AAAAA 0 A_CustomMissile ("SuperWallRedBlood", 40, 0, random (0, 360), 2, random (-15, 15))
+		TNT1 AAAAAAAAA 0 A_CustomMissile ("CeilBloodLauncherLong", 0, 0, random (0, 360), 2, random (50, 130))
+		TNT1 A 0 A_CustomMissile ("XDeathSergeantHeadOnXDeath", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_CustomMissile ("XDeathArm1", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AA 0 A_CustomMissile ("XDeath1", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AAA 0 A_CustomMissile ("SuperGoreSpawner", 30, 0, random (0, 360), 2, random (30, 60))
+		TNT1 AAAA 0 A_CustomMissile ("XDeath2b", 15, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AAAA 0 A_CustomMissile ("XDeath3b", 15, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AA 0 A_CustomMissile ("XDeathSkinPiece2", 15, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AA 0 A_CustomMissile ("XDeathSkinPiece1", 15, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_CustomMissile ("XDeathOrgan1", 24, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_CustomMissile ("XDeathOrgan2", 24, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_CustomMissile ("XDeathHalfShotgunguyNoArmNoHead", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AAAAAAA 0 A_CustomMissile ("Guts", 32, 0, random (0, 360), 2, random (60, 90))
+		TNT1 A 0 A_CustomMissile ("XDeathSargeLeg2", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_CustomMissile ("GibSargeBoot", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_SpawnItem ("BigBloodSpot")
+		TNT1 A 1
+		TNT1 AAAAAA 0 A_CustomMissile ("BloodMistExtraBig", 30, 0, random (0, 360), 2, random (40, 90))
 		Stop
 	}
 }

--- a/ZmanShield.txt
+++ b/ZmanShield.txt
@@ -172,7 +172,24 @@ ACTOR ThrowedZman
 	Death.Explosive:
 	Death.Shotgun:
 		TNT1 A 0
-		TNT1 A 0 A_SpawnItem("ZombieXDeath")
+		TNT1 AAAAA 0 A_CustomMissile ("SuperWallRedBlood", 40, 0, random (0, 360), 2, random (-15, 15))
+		TNT1 AAAAAAAAA 0 A_CustomMissile ("CeilBloodLauncherLong", 0, 0, random (0, 360), 2, random (50, 130))
+		TNT1 A 0 A_CustomMissile ("XDeathZombiemanHeadOnXDeath", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_CustomMissile ("XDeathArm1", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AA 0 A_CustomMissile ("XDeath1", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_CustomMissile ("XDeathHalfZombiemanNoArmNoHead", 48, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AAA 0 A_CustomMissile ("SuperGoreSpawner", 30, 0, random (0, 360), 2, random (30, 60))
+		TNT1 AAAA 0 A_CustomMissile ("XDeath2b", 15, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AAAA 0 A_CustomMissile ("XDeath3b", 15, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AA 0 A_CustomMissile ("XDeathSkinPiece2", 15, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AA 0 A_CustomMissile ("XDeathSkinPiece1", 15, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_CustomMissile ("XDeathOrgan1", 24, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_CustomMissile ("XDeathOrgan2", 24, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AAAAAAA 0 A_CustomMissile ("Guts", 32, 0, random (0, 360), 2, random (60, 90))
+		TNT1 A 0 A_CustomMissile ("XDeathZombieLeg", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_CustomMissile ("GibZombieBoot", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_SpawnItem ("BigBloodSpot")
+		TNT1 AAAAAA 0 A_CustomMissile ("BloodMistExtraBig", 30, 0, random (0, 360), 2, random (40, 90))
 		Stop
 	}
 }

--- a/ZmanShield.txt
+++ b/ZmanShield.txt
@@ -278,7 +278,23 @@ ACTOR ThrowedZmanNoHead
 	Death.Explosive:
 	Death.Shotgun:
 		TNT1 A 0
-		TNT1 A 0 A_SpawnItem("ZombieXDeath")
+		TNT1 AAAAA 0 A_CustomMissile ("SuperWallRedBlood", 40, 0, random (0, 360), 2, random (-15, 15))
+		TNT1 AAAAAAAAA 0 A_CustomMissile ("CeilBloodLauncherLong", 0, 0, random (0, 360), 2, random (50, 130))
+		TNT1 A 0 A_CustomMissile ("XDeathArm1", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AA 0 A_CustomMissile ("XDeath1", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_CustomMissile ("XDeathHalfZombiemanNoArmNoHead", 48, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AAA 0 A_CustomMissile ("SuperGoreSpawner", 30, 0, random (0, 360), 2, random (30, 60))
+		TNT1 AAAA 0 A_CustomMissile ("XDeath2b", 15, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AAAA 0 A_CustomMissile ("XDeath3b", 15, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AA 0 A_CustomMissile ("XDeathSkinPiece2", 15, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AA 0 A_CustomMissile ("XDeathSkinPiece1", 15, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_CustomMissile ("XDeathOrgan1", 24, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_CustomMissile ("XDeathOrgan2", 24, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AAAAAAA 0 A_CustomMissile ("Guts", 32, 0, random (0, 360), 2, random (60, 90))
+		TNT1 A 0 A_CustomMissile ("XDeathZombieLeg", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_CustomMissile ("GibZombieBoot", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_SpawnItem ("BigBloodSpot")
+		TNT1 AAAAAA 0 A_CustomMissile ("BloodMistExtraBig", 30, 0, random (0, 360), 2, random (40, 90))
 		Stop
 	}
 }

--- a/ZombieCivilianShield.txt
+++ b/ZombieCivilianShield.txt
@@ -152,7 +152,25 @@ ACTOR ThrowedZombieCivilian: ThrowedZman
 	Death.Explosive:
 	Death.Chaingun:
 		TNT1 A 0
-		TNT1 A 0 A_SpawnItem("SargeXDeath")
+		TNT1 AAAAA 0 A_CustomMissile ("SuperWallRedBlood", 40, 0, random (0, 360), 2, random (-15, 15))
+		TNT1 AAAAAAAAA 0 A_CustomMissile ("CeilBloodLauncherLong", 0, 0, random (0, 360), 2, random (50, 130))
+		TNT1 A 0 A_CustomMissile ("LabguyHead", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_CustomMissile ("XDeathArm1", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AA 0 A_CustomMissile ("XDeath1", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AAA 0 A_CustomMissile ("SuperGoreSpawner", 30, 0, random (0, 360), 2, random (30, 60))
+		TNT1 AAAA 0 A_CustomMissile ("XDeath2b", 15, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AAAA 0 A_CustomMissile ("XDeath3b", 15, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AA 0 A_CustomMissile ("XDeathSkinPiece2", 15, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AA 0 A_CustomMissile ("XDeathSkinPiece1", 15, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_CustomMissile ("XDeathOrgan1", 24, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_CustomMissile ("XDeathOrgan2", 24, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_CustomMissile ("XDeathHalfShotgunguyNoArmNoHead", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AAAAAAA 0 A_CustomMissile ("Guts", 32, 0, random (0, 360), 2, random (60, 90))
+		TNT1 A 0 A_CustomMissile ("XDeathSargeLeg2", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_CustomMissile ("GibSargeBoot", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_SpawnItem ("BigBloodSpot")
+		TNT1 A 1
+		TNT1 AAAAAA 0 A_CustomMissile ("BloodMistExtraBig", 30, 0, random (0, 360), 2, random (40, 90))
 		Stop
 	}
 }

--- a/ZombieCivilianShield.txt
+++ b/ZombieCivilianShield.txt
@@ -147,6 +147,7 @@ ACTOR ThrowedZombieCivilian: ThrowedZman
 		NULL A 0 A_CustomMissile ("ThrowedZombieCivilianRicochet", 0, 0, 180, 2, 32)
 		Stop
 
+	Death.Shotgun:
 	Death.Gibs:
 	Death.Explosive:
 	Death.Chaingun:
@@ -235,11 +236,29 @@ ACTOR ThrowedZombieCivilianNoHead: ThrowedZombieCivilian
 		NULL A 0 A_CustomMissile ("ThrowedZombieCivilianNoHeadRicochet", 0, 0, 180, 2, 32)
 		Stop
 
+	Death.Shotgun:
 	Death.Gibs:
 	Death.Explosive:
 	Death.Chaingun:
 		TNT1 A 0
-		TNT1 A 0 A_SpawnItem("SargeXDeath")
+		TNT1 AAAAA 0 A_CustomMissile ("SuperWallRedBlood", 40, 0, random (0, 360), 2, random (-15, 15))
+		TNT1 AAAAAAAAA 0 A_CustomMissile ("CeilBloodLauncherLong", 0, 0, random (0, 360), 2, random (50, 130))
+		TNT1 A 0 A_CustomMissile ("XDeathArm1", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AA 0 A_CustomMissile ("XDeath1", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AAA 0 A_CustomMissile ("SuperGoreSpawner", 30, 0, random (0, 360), 2, random (30, 60))
+		TNT1 AAAA 0 A_CustomMissile ("XDeath2b", 15, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AAAA 0 A_CustomMissile ("XDeath3b", 15, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AA 0 A_CustomMissile ("XDeathSkinPiece2", 15, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AA 0 A_CustomMissile ("XDeathSkinPiece1", 15, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_CustomMissile ("XDeathOrgan1", 24, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_CustomMissile ("XDeathOrgan2", 24, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_CustomMissile ("XDeathHalfShotgunguyNoArmNoHead", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 AAAAAAA 0 A_CustomMissile ("Guts", 32, 0, random (0, 360), 2, random (60, 90))
+		TNT1 A 0 A_CustomMissile ("XDeathSargeLeg2", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_CustomMissile ("GibSargeBoot", 32, 0, random (0, 360), 2, random (10, 90))
+		TNT1 A 0 A_SpawnItem ("BigBloodSpot")
+		TNT1 A 1
+		TNT1 AAAAAA 0 A_CustomMissile ("BloodMistExtraBig", 30, 0, random (0, 360), 2, random (40, 90))
 		Stop
 	}
 }


### PR DESCRIPTION
Headless thrown enemies casually spawn a head upon getting gibbed. And under certain states they also spawned incorrect body parts